### PR TITLE
Fixes incomplete requisites for fpm.init

### DIFF
--- a/php/ng/fpm/init.sls
+++ b/php/ng/fpm/init.sls
@@ -13,3 +13,11 @@ extend:
         - file: php_fpm_conf_config
       - require:
         - sls: php.ng.fpm.config
+  php_fpm_ini_config:
+    file:
+      - require:
+        - pkg: php_install_fpm
+  php_fpm_conf_config:
+    file:
+      - require:
+        - pkg: php_install_fpm


### PR DESCRIPTION
Just a little housecleaning for requisites to ensure that all variations of the states work.
