### PR TITLE
Added mongo extension via pecl and use ppa for php

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Installs the php-fpm package, starts the service, and enables it.
 Installs the php-gd package.
 
 ``php.intl``
-----------
+------------
 
 Installs the php-intl package.
 
@@ -133,6 +133,11 @@ Installs the php-soap package.
 ---------------
 
 Installs the php-suhosin package.
+
+``php.mongo``
+-------------
+
+Installs the php-mongo package.
 
 ``php.xml``
 -----------

--- a/php/dev.sls
+++ b/php/dev.sls
@@ -1,0 +1,6 @@
+{% from "php/map.jinja" import php with context %}
+
+php-dev:
+  pkg:
+    - installed
+    - name: {{ php.dev_pkg }}

--- a/php/init.sls
+++ b/php/init.sls
@@ -1,5 +1,20 @@
 {% from "php/map.jinja" import php with context %}
 
+{% if grains['os_family']=="Debian" %}
+{% if use_ppa is not none %}
+
+{% set use_ppa        = salt['pillar.get']('php:use_ppa', none) %}
+{% set ppa_name        = salt['pillar.get']('php:ppa_name', 'ondrej/php5') %}
+
+php54:
+    pkgrepo.managed:
+        - ppa: {{ ppa_name }}
+    pkg.latest:
+        - name: php5
+        - refresh: True
+{% endif %}
+{% endif %}
+
 php:
   pkg:
     - installed

--- a/php/map.jinja
+++ b/php/map.jinja
@@ -26,6 +26,10 @@
         'pgsql_pkg': 'php5-pgsql',
         'ldap_pkg': 'php5-ldap',
         'php_ini': '/etc/php5/apache2/php.ini',
+        'dev_pkg': 'php5-dev',
+        'mongo_pecl': 'mongo',
+        'mongo_ext': 'mongo.so',
+        'ext_conf_path': '/etc/php5/mods-available',
     },
     'RedHat': {
         'php_pkg': 'php',
@@ -54,5 +58,9 @@
         'pgsql_pkg': 'php-pgsql',
         'ldap_pkg': 'php-ldap',
         'php_ini': '/etc/php.ini',
+        'dev_pkg': 'php-dev',
+        'mongo_pecl': 'mongo',
+        'mongo_ext': 'mongo.so',
+        'ext_conf_path': '/etc/php5/conf.d',
     },
 }, merge=salt['pillar.get']('php:lookup')) %}

--- a/php/mongo.sls
+++ b/php/mongo.sls
@@ -1,0 +1,32 @@
+{% from "php/map.jinja"  import php with context %}
+
+{% set version = salt['pillar.get']('php:mongo_version', none) %}
+
+include:
+  - php
+  - php.dev
+  - php.pear
+
+php-mongo:
+  pecl.installed:
+    - name: {{ php.mongo_pecl }}
+    - require:
+      - pkg: {{ php.pear_pkg }}
+    - defaults: True
+{% if version is not none %}
+    - version: {{ version }}
+{% endif %}
+
+php-mongo-conf:
+  file.managed:
+    - name: {{ php.ext_conf_path }}/mongo.ini
+    - contents: |
+        extension={{ php.mongo_ext }}
+    - require:
+      - pkg: {{ php.php_pkg }}
+
+php-mongo-enable:
+  cmd.run:
+    - name: php5enmod mongo
+    - require:
+      - file: php-mongo-conf


### PR DESCRIPTION
Just added `php.mongo` state and allows anyone to use `ppa` instead the default repository

In your state file:

```
include:
  - php.mongo
```

In your pillar:

```
php:
  use_ppa: True
```
