### PR TITLE
Make use_ppa optional

### DIFF
--- a/php/init.sls
+++ b/php/init.sls
@@ -1,9 +1,9 @@
 {% from "php/map.jinja" import php with context %}
 
 {% if grains['os_family']=="Debian" %}
+{% set use_ppa        = salt['pillar.get']('php:use_ppa', none) %}
 {% if use_ppa is not none %}
 
-{% set use_ppa        = salt['pillar.get']('php:use_ppa', none) %}
 {% set ppa_name        = salt['pillar.get']('php:ppa_name', 'ondrej/php5') %}
 
 php54:


### PR DESCRIPTION
Follow-up to #19.

`{% if use_ppa is not none %}` in init.sls always evaluates to true, so on Debian family OSes, the formula will fail unless you provide a ppa_name in a pillar.

This change just moves up the `set use_ppa` line so the evaluation happens against the pillar data.

Before this change, I was seeing things like:

```
          ID: php54
    Function: pkgrepo.managed
      Result: False
     Comment: Failed to confirm config of repo 'php54': repo 'php54' was not found
     Changes: 
```

And also before patching "php54" was being appended to /etc/apt/sources.list which broke some other things:

```
          ID: apache
    Function: pkg.installed
        Name: apache2
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1379, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/states/pkg.py", line 468, in installed
                  **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/states/pkg.py", line 130, in _find_install_targets
                  cur_pkgs = __salt__['pkg.list_pkgs'](versions_as_list=True, **kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/modules/aptpkg.py", line 703, in list_pkgs
                  virtpkgs_all = _get_virtual()
                File "/usr/lib/python2.7/dist-packages/salt/modules/aptpkg.py", line 132, in _get_virtual
                  apt_cache = apt.cache.Cache()
                File "/usr/lib/python2.7/dist-packages/apt/cache.py", line 102, in __init__
                  self.open(progress)
                File "/usr/lib/python2.7/dist-packages/apt/cache.py", line 149, in open
                  self._list.read_main_list()
              SystemError: E:Type 'php54' is not known on line 16 in source list /etc/apt/sources.list
     Changes: 
```

It gets fun if you run it repeatedly because it just keeps appending and you end up with:

```
SystemError: E:Type 'php54php54php54php54' is not known on line 16 in source list /etc/apt/sources.list
```
