### PR TITLE
add libapache2-mod-php5 options on debian only

### DIFF
--- a/php/ng/apache2/ini.sls
+++ b/php/ng/apache2/ini.sls
@@ -1,0 +1,9 @@
+# Manages the libapache2-mod-php5 main ini file
+{% from 'php/ng/map.jinja' import php with context %}
+{% from "php/ng/ini.jinja" import php_ini %}
+
+{% set settings = php.ini.defaults %}
+{% do settings.update(php.apache2.ini.settings) %}
+
+php_apache2_ini:
+  {{ php_ini(php.lookup.apache2.ini, php.apache2.ini.opts, settings) }}

--- a/php/ng/apache2/init.sls
+++ b/php/ng/apache2/init.sls
@@ -1,0 +1,14 @@
+# Installs libapache2-mod-php5 package and manages the associated php.ini on os Debian
+{% if grains['os_family']=="Debian" %}
+
+include:
+  - php.ng.apache2.install
+  - php.ng.apache2.ini
+
+extend:
+  php_apache2_ini:
+    file:
+      - require:
+        - sls: php.ng.apache2.install
+
+{% endif %} #END: os = debian

--- a/php/ng/apache2/install.sls
+++ b/php/ng/apache2/install.sls
@@ -1,0 +1,2 @@
+{% set state = 'apache2' %}
+{% include "php/ng/installed.jinja" %}

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -6,6 +6,7 @@
                 'apc': 'php-apc',
                 'cgi': 'php5-cgi',
                 'cli': 'php5-cli',
+                'apache2': 'libapache2-mod-php5',
                 'curl': 'php5-curl',
                 'fpm': 'php5-fpm',
                 'gd': 'php5-gd',
@@ -43,6 +44,9 @@
             },
             'cli': {
                 'ini': '/etc/php5/cli/php.ini',
+            },
+            'apache2': {
+                'ini': '/etc/php5/apache2/php.ini',
             },
         },
         'RedHat': {
@@ -111,6 +115,12 @@
     'cli': {
         'ini': {
    	        'opts': {},
+            'settings': {},
+        }
+    },
+    'apache2': {
+        'ini': {
+            'opts': {},
             'settings': {},
         }
     },


### PR DESCRIPTION
This adds php.ng.apache2 to manage libapache2-mod-php5 and /etc/php5/apache2/php.ini

This is almost identical to the php.ng.cli state.