### PR TITLE
Add php.composer state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,11 @@ Installs the php-cgi package.
 
 Installs the php-cli package.
 
+``php.composer``
+-----------
+
+Installs [composer](https://getcomposer.org) and keeps it updated.
+
 ``php.curl``
 ------------
 

--- a/php/composer.sls
+++ b/php/composer.sls
@@ -1,0 +1,34 @@
+{% from "php/map.jinja" import php with context %}
+{% set install_file = php.local_bin + '/composer' %}
+
+include:
+  - php
+
+get-composer:
+  cmd.run:
+    - name: 'CURL=`which curl`; $CURL -sS https://getcomposer.org/installer | php'
+    - unless: test -f {{ install_file }}
+    - cwd: {{ php.temp_dir }}
+    - require:
+      - pkg: php
+
+# Get COMPOSER_DEV_WARNING_TIME from the installed composer, and if that time has passed
+# then it's time to run `composer selfupdate`
+#
+# It would be nice if composer had a command line switch to get this, but it doesn't,
+# and so we just grep for it.
+#
+update-composer:
+  cmd.run:
+    - name: "{{ install_file }} selfupdate"
+    - unless: "WARNING_TIME=$(grep --text COMPOSER_DEV_WARNING_TIME {{ install_file }} | egrep '^\s*define' | sed -e 's,[^[:digit:]],,g'); php -r \"exit($WARNING_TIME > time() ? 0 : 1);\""
+    - cwd: {{ php.temp_dir }}
+    - require:
+      - cmd: get-composer
+
+install-composer:
+  cmd.wait:
+    - name: install -m 0755 {{ php.temp_dir }}/composer.phar {{ install_file }}
+    - cwd: {{ php.temp_dir }}
+    - watch:
+      - cmd: get-composer

--- a/php/composer.sls
+++ b/php/composer.sls
@@ -12,6 +12,13 @@ get-composer:
     - require:
       - pkg: php
 
+install-composer:
+  cmd.wait:
+    - name: mv {{ php.temp_dir }}/composer.phar {{ install_file }}
+    - cwd: {{ php.temp_dir }}
+    - watch:
+      - cmd: get-composer
+
 # Get COMPOSER_DEV_WARNING_TIME from the installed composer, and if that time has passed
 # then it's time to run `composer selfupdate`
 #
@@ -24,11 +31,4 @@ update-composer:
     - unless: test $(grep --text COMPOSER_DEV_WARNING_TIME {{ install_file }} | egrep '^\s*define' | sed -e 's,[^[:digit:]],,g') \> $(php -r 'echo time();')
     - cwd: {{ php.temp_dir }}
     - require:
-      - cmd: get-composer
-
-install-composer:
-  cmd.wait:
-    - name: install -m 0755 {{ php.temp_dir }}/composer.phar {{ install_file }}
-    - cwd: {{ php.temp_dir }}
-    - watch:
-      - cmd: get-composer
+      - cmd: install-composer

--- a/php/composer.sls
+++ b/php/composer.sls
@@ -21,7 +21,7 @@ get-composer:
 update-composer:
   cmd.run:
     - name: "{{ install_file }} selfupdate"
-    - unless: "WARNING_TIME=$(grep --text COMPOSER_DEV_WARNING_TIME {{ install_file }} | egrep '^\s*define' | sed -e 's,[^[:digit:]],,g'); php -r \"exit($WARNING_TIME > time() ? 0 : 1);\""
+    - unless: test $(grep --text COMPOSER_DEV_WARNING_TIME {{ install_file }} | egrep '^\s*define' | sed -e 's,[^[:digit:]],,g') \> $(php -r 'echo time();')
     - cwd: {{ php.temp_dir }}
     - require:
       - cmd: get-composer

--- a/php/map.jinja
+++ b/php/map.jinja
@@ -31,6 +31,8 @@
         'mongo_pecl': 'mongo',
         'mongo_ext': 'mongo.so',
         'ext_conf_path': '/etc/php5/mods-available',
+        'local_bin': '/usr/local/bin',
+        'temp_dir': '/tmp',
     },
     'RedHat': {
         'php_pkg': 'php',
@@ -64,5 +66,7 @@
         'mongo_pecl': 'mongo',
         'mongo_ext': 'mongo.so',
         'ext_conf_path': '/etc/php5/conf.d',
+        'local_bin': '/usr/local/bin',
+        'temp_dir': '/tmp',
     },
 }, merge=salt['pillar.get']('php:lookup')) %}


### PR DESCRIPTION
Added php.composer which contains much of the same SLS suggested by the composer salt state at http://docs.saltstack.com/en/latest/ref/states/all/salt.states.composer.html

In addition to that, I added `cmd: update-composer` which will run `composer selfupdate` if it is out-of-date.

Presently the check for "is out of date" is hackish, because Composer doesn't give us any way to check it by version compares, but it's functional.  Ideally they would add some visibility into the question of "is composer outdated" and we could then upgrade that piece.

Anyway it made a lot more sense to me for this to live in php-formula rather than having to cut/paste a wall of text into every salt project that wants to use composer, so here it is.