### PR TITLE
Fix Debian package name for `php.ng.xml` state

### DIFF
--- a/php/map.jinja
+++ b/php/map.jinja
@@ -22,7 +22,7 @@
       	'sqlite_pkg': 'php5-sqlite',
         'redis_pkg': 'php5-redis',
         'fpm_service': 'php5-fpm',
-        'xml_pkg': 'php5-xml',
+        'xml_pkg': 'php5',
         'imagick_pkg': 'php5-imagick',
         'suhosin_pkg': 'php5-suhosin',
         'imap_pkg': 'php5-imap',

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -26,7 +26,7 @@
                 'sqlite': 'php5-sqlite',
                 'xdebug': 'php5-xdebug',
                 'xsl': 'php5-xsl',
-                'xml': 'php5-xmlrpc',
+                'xml': 'php5',
                 'redis': 'php5-redis',
                 'imagick': 'php5-imagick',
                 'suhosin': 'php5-suhosin',


### PR DESCRIPTION
XML module is already built-in. In any case, `php5-xmlrpc` package actually provides XML-RPC module.