### PR TITLE
Add support for GMP ext

### DIFF
--- a/php/ng/gmp.sls
+++ b/php/ng/gmp.sls
@@ -1,0 +1,2 @@
+{% set state = 'gmp' %}
+{% include "php/ng/installed.jinja" %}

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -12,6 +12,7 @@
                 'curl': 'php5-curl',
                 'fpm': 'php5-fpm',
                 'gd': 'php5-gd',
+                'gmp': 'php5-gmp',
                 'geoip': 'php5-geoip',
                 'intl': 'php5-intl',
                 'mbstring': 'php5',


### PR DESCRIPTION
GMP is an extension used for dealing with huge numbers that PHP cannot support by default