### PR TITLE
Update Composer state file to not use curl

### DIFF
--- a/php/map.jinja
+++ b/php/map.jinja
@@ -36,6 +36,8 @@
         'ext_conf_path': '/etc/php5/mods-available',
         'local_bin': '/usr/local/bin',
         'temp_dir': '/tmp',
+        'composer_bin': 'composer',
+        'composer_hash': 'sha256=6a1ba6495f0bdb8e7735a7a76948b61c54b4a57b56837a9e9f93b4a0ac1f83a5',
     },
     'RedHat': {
         'php_pkg': 'php',
@@ -74,6 +76,8 @@
         'ext_conf_path': '/etc/php5/conf.d',
         'local_bin': '/usr/local/bin',
         'temp_dir': '/tmp',
+        'composer_bin': 'composer',
+        'composer_hash': 'sha256=6a1ba6495f0bdb8e7735a7a76948b61c54b4a57b56837a9e9f93b4a0ac1f83a5',
     },
     'Suse': {
         'php_pkg': 'php5',
@@ -103,5 +107,7 @@
         'ext_conf_path': '/etc/php5/conf.d',
         'local_bin': '/usr/local/bin',
         'temp_dir': '/tmp',
+        'composer_bin': 'composer',
+        'composer_hash': 'sha256=6a1ba6495f0bdb8e7735a7a76948b61c54b4a57b56837a9e9f93b4a0ac1f83a5',
     },
 }, merge=salt['pillar.get']('php:lookup')) %}


### PR DESCRIPTION
Curl seems like an unnecessary dependency when the Composer installer already has the necessary options to download the composer binary to a specified directory and file name.

file.managed does require a source_hash of the installer file, *not the composer binary*, but that can be updated in the map.jinja file or overridden in the pillar data. As well as being able to set the composer binary file name in the pillar data.