### PR TITLE
Recursively merge php.ini options

### DIFF
--- a/php/ng/cli/ini.sls
+++ b/php/ng/cli/ini.sls
@@ -3,7 +3,13 @@
 {% from "php/ng/ini.jinja" import php_ini %}
 
 {% set settings = php.ini.defaults %}
-{% do settings.update(php.cli.ini.settings) %}
+{% for key, value in php.cli.ini.settings.iteritems() %}
+  {% if settings[key] is defined %}
+    {% do settings[key].update(value) %}
+  {% else %}
+    {% do settings.update({key: value}) %}
+  {% endif %}
+{% endfor %}
 
 php_cli_ini:
   {{ php_ini(php.lookup.cli.ini, php.cli.ini.opts, settings) }}

--- a/php/ng/fpm/config.sls
+++ b/php/ng/fpm/config.sls
@@ -3,7 +3,13 @@
 {% from "php/ng/ini.jinja" import php_ini %}
 
 {% set ini_settings = php.ini.defaults %}
-{% do ini_settings.update(php.fpm.config.ini.settings) %}
+{% for key, value in php.fpm.config.ini.settings.iteritems() %}
+  {% if ini_settings[key] is defined %}
+    {% do ini_settings[key].update(value) %}
+  {% else %}
+    {% do ini_settings.update({key: value}) %}
+  {% endif %}
+{% endfor %}
 
 {% set conf_settings = php.lookup.fpm.defaults %}
 {% do conf_settings.update(php.fpm.config.conf.settings) %}


### PR DESCRIPTION
Options under `php.fpm.config.ini.settings` and `php.cli.ini.settings` should be merged with `php.ini.defaults`