### PR TITLE
Fix install-composer edge cases

### DIFF
--- a/php/composer.sls
+++ b/php/composer.sls
@@ -15,9 +15,10 @@ get-composer:
       - pkg: php
 
 install-composer:
-  cmd.wait:
+  cmd.run:
     - name: {{ php.temp_dir }}/installer --filename={{ php.composer_bin }} --install-dir={{ php.local_bin }}
-    - watch:
+    - unless: test -f {{ install_file }}
+    - require:
       - file: get-composer
 
 # Get COMPOSER_DEV_WARNING_TIME from the installed composer, and if that time has passed


### PR DESCRIPTION
If the initial run of `install-composer` fails it will not be attempted again until `get-composer` changes states, which in this case means it will not be attempted again until `/tmp/installer` is removed.

Similarly, if `{{ php.composer_bin }}` or `{{ php.local_bin }}` are changed, composer would not be installed again to reflect these changes in the pillar data.

This pull request resolves this issue by switching to cmd.run and relying on an unless condition to prevent unnecesary execution of `install-composer`.
