### PR TITLE
changed Debian hhvm PID filepath to match default /etc/init.d/hhvm PID filepath

### DIFF
--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -58,7 +58,7 @@
                 'service': 'hhvm',
                 'defaults': {},
                 'server': odict([
-                    ('pid', '/var/run/hhvm.pid'),
+                    ('pid', '/var/run/hhvm/pid'),
                     ('hhvm.server.port', '9000'),
                     ('hhvm.server.type', 'fastcgi'),
                     ('hhvm.server.default_document', 'index.php'),


### PR DESCRIPTION
regarding https://github.com/saltstack-formulas/php-formula/issues/65

only tested on Ubuntu 14.04.