### PR TITLE
Manually add php PPA in UTF-8 locale [Resolves #69]

### DIFF
--- a/php/ng/installed.jinja
+++ b/php/ng/installed.jinja
@@ -26,13 +26,25 @@
 
 {% set ppa_name        = salt['pillar.get']('php:ppa_name', 'ondrej/php5') %}
 
+php_ppa_env_{{ state }}:
+    cmd.run:
+        - name: apt-add-repository -y ppa:{{ ppa_name }}
+        - env:
+            - LC_ALL: C.UTF-8
+
 php_ppa_{{ state }}:
     pkgrepo.managed:
         - ppa: {{ ppa_name }}
+        - require:
+            - cmd: php_ppa_env_{{ state }}
+        - require_in:
+            - pkg: php_install_{{ state }}
     pkg.latest:
         - name: {{ state }}
         - pkgs: {{ pkgs|json() }}
         - refresh: True
+        - onchanges:
+            - pkgrepo: php_ppa_{{ state }}
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
This is a work-around #69 which is being caused by saltstack/salt#23543 due to UTF-8 characters appearing in the PPA creator's name.  The solution is taken from @RyPeck, but is not really ideal because it adds a commented deb-src line to the .list file each time the state is run.