### PR TITLE
Only add ppa if it doesn't exist.

### DIFF
--- a/php/ng/installed.jinja
+++ b/php/ng/installed.jinja
@@ -31,6 +31,7 @@ php_ppa_env_{{ state }}:
         - name: apt-add-repository -y ppa:{{ ppa_name }}
         - env:
             - LC_ALL: C.UTF-8
+        - unless: test /etc/apt/sources.list.d/{{ ppa_name|replace('/', '-', 1) }}-trusty.list
 
 php_ppa_{{ state }}:
     pkgrepo.managed:


### PR DESCRIPTION
This comit is in addition to pull request #70. The add-apt-repository command
will only be run when the ppa has not yet been added.