### PR TITLE
Update composer installer sha256 hash

### DIFF
--- a/php/map.jinja
+++ b/php/map.jinja
@@ -70,7 +70,7 @@
         'local_bin': '/usr/local/bin',
         'temp_dir': '/tmp',
         'composer_bin': 'composer',
-        'composer_hash': 'sha256=6a1ba6495f0bdb8e7735a7a76948b61c54b4a57b56837a9e9f93b4a0ac1f83a5',
+        'composer_hash': 'sha256=50b383348173bd454ed8d962253a85b7d194f071e3f8e7f74817512221efc569',
     },
     'RedHat': {
         'php_pkg': 'php',
@@ -111,7 +111,7 @@
         'local_bin': '/usr/local/bin',
         'temp_dir': '/tmp',
         'composer_bin': 'composer',
-        'composer_hash': 'sha256=6a1ba6495f0bdb8e7735a7a76948b61c54b4a57b56837a9e9f93b4a0ac1f83a5',
+        'composer_hash': 'sha256=50b383348173bd454ed8d962253a85b7d194f071e3f8e7f74817512221efc569',
     },
     'Suse': {
         'php_pkg': 'php5',
@@ -143,7 +143,7 @@
         'local_bin': '/usr/local/bin',
         'temp_dir': '/tmp',
         'composer_bin': 'composer',
-        'composer_hash': 'sha256=6a1ba6495f0bdb8e7735a7a76948b61c54b4a57b56837a9e9f93b4a0ac1f83a5',
+        'composer_hash': 'sha256=50b383348173bd454ed8d962253a85b7d194f071e3f8e7f74817512221efc569',
     },
 }, merge=salt['pillar.get']('php:lookup')) %}
 


### PR DESCRIPTION
We probably want to address the underlying issue (i.e. checksum checking) in the future, but this allows installations to continue for now.