### PR TITLE
Explicitly set HOME when running composer install.

### DIFF
--- a/php/composer.sls
+++ b/php/composer.sls
@@ -1,6 +1,14 @@
 {% from "php/map.jinja" import php with context %}
 {% set install_file = php.local_bin + '/' + php.composer_bin %}
 
+{% if not salt['config.get']('sudo_user') %}
+{% set salt_user = salt['config.get']('user', 'root') %}
+{% else %}
+{% set salt_user = salt['config.get']('sudo_user', 'root') %}
+{% endif %}
+
+{% set salt_user_home = salt['user.info'](salt_user).get('home', '/root') %}
+
 include:
   - php
 
@@ -18,6 +26,8 @@ install-composer:
   cmd.run:
     - name: php {{ php.temp_dir }}/installer --filename={{ php.composer_bin }} --install-dir={{ php.local_bin }}
     - unless: test -f {{ install_file }}
+    - env:
+      - HOME: {{ salt_user_home }}
     - require:
       - file: get-composer
 
@@ -32,5 +42,7 @@ update-composer:
     - name: "{{ install_file }} selfupdate"
     - unless: test $(grep --text COMPOSER_DEV_WARNING_TIME {{ install_file }} | egrep '^\s*define' | sed -e 's,[^[:digit:]],,g') \> $(php -r 'echo time();')
     - cwd: {{ php.local_bin }}
+    - env:
+      - HOME: {{ salt_user_home }}
     - require:
       - cmd: install-composer


### PR DESCRIPTION
Without this installation and updates fail with:

  The HOME or COMPOSER_HOME environment variable must be set for
  composer to install correctly