### PR TITLE
Do not hardcode composer checksum

### DIFF
--- a/php/composer.sls
+++ b/php/composer.sls
@@ -18,7 +18,7 @@ get-composer:
     - mode: 0755
     - unless: test -f {{ install_file }}
     - source: https://getcomposer.org/installer
-    - source_hash: {{ php.composer_hash }}
+    - source_hash: https://composer.github.io/installer.sig
     - require:
       - pkg: php
 

--- a/php/map.jinja
+++ b/php/map.jinja
@@ -70,7 +70,6 @@
         'local_bin': '/usr/local/bin',
         'temp_dir': '/tmp',
         'composer_bin': 'composer',
-        'composer_hash': 'sha256=50b383348173bd454ed8d962253a85b7d194f071e3f8e7f74817512221efc569',
     },
     'RedHat': {
         'php_pkg': 'php',
@@ -111,7 +110,6 @@
         'local_bin': '/usr/local/bin',
         'temp_dir': '/tmp',
         'composer_bin': 'composer',
-        'composer_hash': 'sha256=50b383348173bd454ed8d962253a85b7d194f071e3f8e7f74817512221efc569',
     },
     'Suse': {
         'php_pkg': 'php5',
@@ -143,7 +141,6 @@
         'local_bin': '/usr/local/bin',
         'temp_dir': '/tmp',
         'composer_bin': 'composer',
-        'composer_hash': 'sha256=50b383348173bd454ed8d962253a85b7d194f071e3f8e7f74817512221efc569',
     },
 }, merge=salt['pillar.get']('php:lookup')) %}
 


### PR DESCRIPTION
This allows composer installs to function even if the installer checksum
changes, and doesn't force us to update the formula all the time.

We can do this now as composer upstream provides the checksum on
https://composer.github.io/installer.sig since 2016-04-28.

See https://composer.github.io/pubkeys.html for further details.