### PR TITLE
support for tidy module, more support for arch-linux

### DIFF
--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -472,6 +472,7 @@
                 'curl': 'curl',
                 'fpm': 'php-fpm',
                 'gd': 'php-gd',
+                'geoip': 'php-geoip',
                 'intl': 'php-intl',
                 'mcrypt': 'php-mcrypt',
                 'memcache': 'php-memcache',

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -481,6 +481,7 @@
                 'xcache': 'php-xcache',
                 'pgsql': 'php-pgsql',
                 'ldap': 'php-ldap',
+                'tidy': 'php-tidy',
             },
             'fpm': {
                 'conf': '/etc/php/php-fpm.conf',

--- a/php/ng/tidy.sls
+++ b/php/ng/tidy.sls
@@ -1,0 +1,2 @@
+{% set state = 'tidy' %}
+{% include "php/ng/installed.jinja" %}


### PR DESCRIPTION
I've added support for the tidy-module (currently only arch tested). Also I added a missing mapping for the geoip module in arch linux