### PR TITLE
add php-apcu for debian stretch (7.0)

### DIFF
--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -3,6 +3,7 @@
     'lookup': salt['grains.filter_by']({
         'Debian': {
             'pkgs': {
+                'apcu': 'php-apcu',
                 'php': 'php7.0',
                 'cgi': 'php7.0-cgi',
                 'cli': 'php7.0-cli',


### PR DESCRIPTION
debian stretch has renamed php5-apcu into php-apcu.
