### PR TITLE
Add php-gearman support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -249,6 +249,11 @@ Installs the php5-curl package on Debian, and ensures that curl itself is
 installed for RedHat systems, this is due to the curl libs being provided by
 php-common, which will get installed with the main php package.
 
+``php.ng.gearman``
+---------------
+
+Installs the php-gearman package.
+
 ``php.ng.fpm``
 --------------
 

--- a/php/ng/gearman.sls
+++ b/php/ng/gearman.sls
@@ -1,0 +1,2 @@
+{% set state = 'gearman' %}
+{% include "php/ng/installed.jinja" %}

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -297,6 +297,7 @@
                 'oauth': 'php5-oauth',
                 'apache2': 'libapache2-mod-php5',
                 'curl': 'php5-curl',
+                'gearman': 'php5-gearman',
                 'fpm': 'php5-fpm',
                 'hhvm': 'hhvm',
                 'gd': 'php5-gd',


### PR DESCRIPTION
This PR adds ``php5-gearman`` support for Debian. I'm not sure about other operating systems whether there is such package or no so I didn't add support.
For now there is no php7.0-gearman package in Debian so I didn't add this to ``map.jinja`` too.
If someone knows package names for other systems I could definitely add them to map.jinja.