### PR TITLE
Allow overwriting the fpm pools config name via 'filename'.

### DIFF
--- a/php/ng/fpm/pools_config.sls
+++ b/php/ng/fpm/pools_config.sls
@@ -11,7 +11,7 @@
 
 {% for pool, config in php.fpm.pools.iteritems() %}
 {% set state = 'php_fpm_pool_conf_' ~ loop.index0 %}
-{% set fpath = path_join(pool, php.lookup.fpm.pools) %}
+{% set fpath = path_join(config.get('filename', pool), php.lookup.fpm.pools) %}
 
 {{ state }}:
 {% if config.enabled %}

--- a/pillar.example
+++ b/pillar.example
@@ -20,9 +20,9 @@ php:
       pkgs:
         memcached: php5-memcached
         # ensures both will be installed
-        curl: 
+        curl:
           - php-common
-          - curl 
+          - curl
         # a dictionary can be used in more complex cases where you want
         # to pass forward special arguments to the pkg.installed call
         # you MUST include the name argument for this to work
@@ -99,6 +99,11 @@ php:
           # If true, the pool file will be managed, if False it will be
           # absent
           enabled: True
+
+          # Overwrite the filename for ext_pillar that doesn't allow
+          # dots in fields names.
+          filname: my_other_name.conf
+
           # arguments passed forward to file.managed or file.absent
           opts:
              replace: False


### PR DESCRIPTION
I need this for the mongo ext_pillar.

https://rene.jochums.at/howto-move-saltstack-tops-and-pillar-contents-to-mongodb
https://rene.jochums.at/having-fun-with-saltstack-and-ext_pillar-mongo

Signed-off-by: Rene Jochum <rene@jochums.at>