### PR TITLE
Add xdebug package for RedHat family operating systems in map.jina

### DIFF
--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -1152,6 +1152,7 @@
                 'soap': 'php-soap',
                 'sqlite': 'php5-sqlite',
                 'xcache': 'php-xcache',
+                'xdebug': 'php-pecl-xdebug',
                 'xml': 'php-xml',
                 'zip': 'php',
                 'redis': 'php-redis',


### PR DESCRIPTION
Tested on Fedora 25. I don't know if the package exists on CentOS / RHEL and if it does, if it has the same name.