### PR TITLE
Fix conflicting IDs using new structure

### DIFF
--- a/php/ng/installed.jinja
+++ b/php/ng/installed.jinja
@@ -47,6 +47,7 @@ php_ppa_{{ state }}:
     - onchanges:
       - pkgrepo: php_ppa_{{ state }}
 
+    {% if state == 'cli' %}
 php_{{ phpng_version }}_link:
   alternatives.set:
     - name: php
@@ -56,6 +57,7 @@ php_{{ phpng_version }}_link:
     - onlyif:
       - which php
       - test {{ current_php }} != $(which php{{ phpng_version }})
+    {% endif %}
 
   {% endif %}
 {% endif %}


### PR DESCRIPTION
Trying to update my servers from php 7.0 to to 7.1 by upgrading to the latest release of this formula after #115.  I get the following error:

    Detected conflicting IDs, SLS IDs need to be globally unique.
    The conflicting ID is 'php_7.1_link' and is found in SLS 'base:php.ng.cli.install' and SLS 'base:php.ng.fpm.install'

This was because I need both php-fpm and the php cli.  I simply restricted the rule to state==cli, but should this be moved into cli/install.sls instead?