### PR TITLE
Improvements to php/ng/map.jinja

### DIFF
--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -1398,6 +1398,327 @@
             }, merge=True) %}
         {%- endif %}
     {%- endif %}
+{%- elif salt['grains.get']('os') == "Debian" %}
+    {%- set phpng_version = salt['pillar.get']('php:ng:version', '7.0')|string %}
+    {%- set php = salt['pillar.get']('php:ng', {
+    'lookup': salt['grains.filter_by']({
+                    'Debian': {
+                        'pkgs': {
+                            'adodb': 'libphp-adodb',
+                            'apache2': 'libapache2-mod-php' + phpng_version,
+                            'apc': 'php-apcu',
+                            'apcu': 'php-apcu-bc',
+                            'bcmath': 'php' + phpng_version + '-bcmath',
+                            'build_pkgs': ['libssl-dev', 'libcurl4-openssl-dev', 'pkg-config', 'libsslcommon2-dev', 'gcc', 'make', 'autoconf', 'libc-dev', 'pkg-config'],
+                            'cache-lite': 'php-cache-lite',
+                            'cgi': 'php' + phpng_version + '-cgi',
+                            'cli': 'php' + phpng_version + '-cli',
+                            'composer_bin': 'composer',
+                            'console-table': 'php-console-table',
+                            'curl': 'php' + phpng_version + '-curl',
+                            'dev': 'php' + phpng_version + '-dev',
+                            'ext_conf_path': '/etc/php/' + phpng_version + '/mods-available',
+                            'fpm': 'php' + phpng_version + '-fpm',
+                            'gd': 'php' + phpng_version + '-gd',
+                            'gearman': 'php-gearman',
+                            'geoip': 'php-geoip',
+                            'geshi': 'php-geshi',
+                            'gettext': 'php' + phpng_version,
+                            'gmp': 'php' + phpng_version + '-gmp',
+                            'hhvm': 'hhvm',
+                            'imagick': 'php-imagick',
+                            'imap': 'php' + phpng_version + '-imap',
+                            'intl': 'php' + phpng_version + '-intl',
+                            'json': 'php' + phpng_version + '-json',
+                            'ldap': 'php' + phpng_version + '-ldap',
+                            'local_bin': '/usr/local/bin',
+                            'mbstring': 'php' + phpng_version + '-mbstring',
+                            'mcrypt': 'php' + phpng_version + '-mcrypt',
+                            'memcache': 'php-memcache',
+                            'memcached': 'php-memcached',
+                            'mongo': 'php-mongo',
+                            'mongodb': 'php-mongodb',
+                            'mysql': 'php' + phpng_version + '-mysql',
+                            'mysqlnd': 'php' + phpng_version + '-mysql',
+                            'net4': 'php-net-ipv4',
+                            'net6': 'php-net-ipv6',
+                            'oauth': 'php-oauth',
+                            'opcache': 'php' + phpng_version + '-opcache',
+                            'pear': 'php-pear',
+                            'pgsql': 'php' + phpng_version + '-pgsql',
+                            'php': 'php' + phpng_version,
+                            'phpenmod_command': 'phpenmod -v' + phpng_version,
+                            'pspell': 'php' + phpng_version + '-pspell',
+                            'redis': 'php' + phpng_version + '-redis',
+                            'seclib': ['php-phpseclib', 'php-seclib'],
+                            'snmp': 'php' + phpng_version + '-snmp',
+                            'soap': 'php' + phpng_version + '-soap',
+                            'ssh2': 'php-ssh2',
+                            'sqlite': 'php' + phpng_version + '-sqlite3',
+                            'suhosin5_ext': 'suhosin.so',
+                            'suhosin5_repo': 'https://github.com/sektioneins/suhosin',
+                            'suhosin7_ext': 'suhosin7.so',
+                            'suhosin7_repo': 'https://github.com/sektioneins/suhosin7',
+                            'tcpdf': 'php-tcpdf',
+                            'temp_dir': '/tmp',
+                            'tidy': 'php' + phpng_version + '-tidy',
+                            'xdebug': 'php' + phpng_version + '-xdebug',
+                            'xml': 'php' + phpng_version + '-xml',
+                            'xsl': 'php' + phpng_version + '-xsl',
+                            'zip': 'php' + phpng_version + '-zip',
+                        },
+                        'fpm': {
+                            'conf': '/etc/php/' + phpng_version + '/fpm/php-fpm.conf',
+                            'ini': '/etc/php/' + phpng_version + '/fpm/php.ini',
+                            'pools': '/etc/php/' + phpng_version + '/fpm/pool.d',
+                            'service': 'php' + phpng_version + '-fpm',
+                            'defaults': odict([
+                                ('global', odict([
+                                    ('pid', '/var/run/php' + phpng_version + '-fpm.pid'),
+                                    ('error_log', '/var/log/php' + phpng_version + '-fpm.log'),
+                                ])),
+                                ('include', '/etc/php/' + phpng_version + '/fpm/pool.d/*.conf'),
+                            ]),
+                        },
+                        'hhvm': {
+                            'conf': '/etc/hhvm/server.ini',
+                            'ini': '/etc/hhvm/php.ini',
+                            'service': 'hhvm',
+                            'defaults': {},
+                            'server': odict([
+                                ('pid', '/var/run/hhvm/pid'),
+                                ('hhvm.server.port', '9000'),
+                                ('hhvm.server.type', 'fastcgi'),
+                                ('hhvm.server.default_document', 'index.php'),
+                                ('hhvm.log.use_log_file', 'true'),
+                                ('hhvm.log.file', '/var/log/hhvm/error.log'),
+                                ('hhvm.repo.central.path', '/var/run/hhvm/hhvm.hhbc'),
+                            ]),
+                            'php': odict([
+                                ('session.save_handler', 'files'),
+                                ('session.save_path', '/var/lib/hhvm/sessions'),
+                                ('session.gc_maxlifetime', '1440'),
+                                ('hhvm.log.level', 'Warning'),
+                                ('hhvm.log.always_log_unhandled_exceptions', 'true'),
+                                ('hhvm.log.runtime_error_reporting_level', '8191'),
+                                ('hhvm.mysql.typed_results', 'false'),
+                            ]),
+                        },
+                        'cli': {
+                            'ini': '/etc/php/' + phpng_version + '/cli/php.ini',
+                        },
+                        'apache2': {
+                            'ini': '/etc/php/' + phpng_version + '/apache2/php.ini',
+                        },
+                    },
+                }),
+                'fpm': {
+                    'service': {
+                        'enabled': True,
+                        'opts': {},
+                    },
+                    'config': {
+                        'ini': {
+                            'opts': {},
+                            'settings': {},
+                        },
+                        'conf': {
+                            'opts': {},
+                            'settings': {},
+                        },
+                    },
+                    'pools': {},
+                },
+                'hhvm': {
+                    'service': {
+                        'enabled': True,
+                        'opts': {},
+                    },
+                    'config': {
+                        'server': {
+                            'opts': {},
+                            'settings': {},
+                        },
+                        'php': {
+                            'opts': {},
+                            'settings': {},
+                        },
+                    },
+                },
+                'cli': {
+                    'ini': {
+                        'opts': {},
+                        'settings': {},
+                    }
+                },
+                'apache2': {
+                    'ini': {
+                        'opts': {},
+                        'settings': {},
+                    }
+                },
+                'ini': {
+                    'defaults': {
+                        'PHP': {
+                            'allow_url_fopen': 'On',
+                            'allow_url_include': 'Off',
+                            'asp_tags': 'Off',
+                            'auto_globals_jit': 'On',
+                            'default_mimetype': '"text/html"',
+                            'default_socket_timeout': 60,
+                            'disable_functions': ['pcntl_alarm','pcntl_fork','pcntl_waitpid','pcntl_wait','pcntl_wifexited','pcntl_wifstopped','pcntl_wifsignaled',
+                                'pcntl_wexitstatus','pcntl_wtermsig','pcntl_wstopsig','pcntl_signal','pcntl_signal_dispatch','pcntl_get_last_error','pcntl_strerror',
+                                'pcntl_sigprocmask','pcntl_sigwaitinfo','pcntl_sigtimedwait','pcntl_exec','pcntl_getpriority','pcntl_setpriority'],
+                            'display_errors': 'Off',
+                            'display_startup_errors': 'Off',
+                            'enable_dl': 'Off',
+                            'engine': 'On',
+                            'error_reporting': ['E_ALL', '~E_DEPRECATED', '~E_STRICT'],
+                            'expose_php': 'On',
+                            'file_uploads': 'On',
+                            'html_errors': 'On',
+                            'ignore_repeated_errors': 'Off',
+                            'ignore_repeated_source': 'Off',
+                            'implicit_flush': 'Off',
+                            'log_errors': 'On',
+                            'log_errors_max_len': 1024,
+                            'max_execution_time': 30,
+                            'max_file_uploads': 20,
+                            'max_input_nesting_level': 64,
+                            'max_input_time': 60,
+                            'max_input_vars': 1000,
+                            'memory_limit': '128M',
+                            'output_buffering': 4096,
+                            'post_max_size': '8M',
+                            'precision': 14,
+                            'register_argc_argv': 'Off',
+                            'report_memleaks': 'On',
+                            'request_order': 'GP',
+                            'serialize_precision': 17,
+                            'short_open_tag': 'Off',
+                            'track_errors': 'Off',
+                            'upload_max_filesize': '2M',
+                            'variables_order': 'GPCS',
+                            'zend.enable_gc': 'On',
+                            'zlib.output_compression': 'Off',
+                        },
+                        'CLI Server': {
+                            'cli_server.color': 'On'
+                        },
+                        'Date': {
+                            'date.timezone': 'America/New_York'
+                        },
+                        'Pdo_mysql': {
+                            'pdo_mysql.cache_size': 2000
+                        },
+                        'mail function': {
+                            'SMTP': 'localhost',
+                            'mail.add_x_header': 'On'
+                        },
+                        'SQL': {
+                            'sql.safe_mode': 'Off'
+                        },
+                        'ODBC': {
+                            'odbc.allow_persistent': 'On',
+                            'odbc.check_persistent': 'On',
+                            'odbc.max_persistent': '-1',
+                            'odbc.max_links': '-1',
+                            'odbc.defaultlrl': 4096,
+                            'odbc.defaultbinmode': 1
+                        },
+                        'Interbase': {
+                            'ibase.allow_persistent': 1,
+                            'ibase.max_persistent': -1,
+                            'ibase.max_links': -1,
+                            'ibase.timestampformat': '"%Y-%m-%d %H:%M:%S"',
+                            'ibase.dateformat': '"%Y-%m-%d"',
+                            'ibase.timeformat': '"%H:%M:%S"'
+                        },
+                        'MySQL': {
+                            'mysql.allow_local_infile': 'On',
+                            'mysql.allow_persistent': 'On',
+                            'mysql.cache_size': '2000',
+                            'mysql.max_persistent': -1,
+                            'mysql.max_links': -1,
+                            'mysql.connect_timeout': 60,
+                            'mysql.trace_mode': 'Off'
+                        },
+                        'MySQLi': {
+                            'mysqli.max_persistent': -1,
+                            'mysqli.allow_persistent': 'On',
+                            'mysqli.max_links': -1,
+                            'mysqli.cache_size': 2000,
+                            'mysqli.default_port': 3306,
+                            'mysqli.reconnect': 'Off'
+                        },
+                        'mysqlnd': {
+                            'mysqlnd.collect_statistics': 'On',
+                            'mysqlnd.collect_memory_statistics': 'Off'
+                        },
+                        'PostgreSQL': {
+                            'pgsql.allow_persistent': 'On',
+                            'pgsql.auto_reset_persistent': 'Off',
+                            'pgsql.max_persistent': -1,
+                            'pgsql.max_links': -1,
+                            'pgsql.ignore_notice': 0,
+                            'pgsql.log_notice': 0
+                        },
+                        'Sybase-CT': {
+                            'sybct.allow_persistent': 'On',
+                            'sybct.max_persistent': -1,
+                            'sybct.max_links': -1,
+                            'sybct.min_server_severity': 10,
+                            'sybct.min_client_severity': 10
+                        },
+                        'bcmath': {
+                            'bcmath.scale': 0
+                        },
+                        'Session': {
+                            'session.save_handler': 'files',
+                            'session.use_strict_mode': 0,
+                            'session.use_cookies': 1,
+                            'session.use_only_cookies': 1,
+                            'session.name': 'PHPSESSID',
+                            'session.auto_start': 0,
+                            'session.cookie_lifetime': 0,
+                            'session.cookie_path': '/',
+                            'session.serialize_handler': 'php',
+                            'session.gc_probability': 0,
+                            'session.gc_divisor': 1000,
+                            'session.gc_maxlifetime': 1440,
+                            'session.bug_compat_42': 'Off',
+                            'session.bug_compat_warn': 'Off',
+                            'session.cache_limiter': 'nocache',
+                            'session.cache_expire': '180',
+                            'session.use_trans_sid': 0,
+                            'session.hash_function': 0,
+                            'session.hash_bits_per_character': 5,
+                            'url_rewriter.tags': '"a=href,area=href,frame=src,input=src,form=fakeentry"'
+                        },
+                        'MSSQL': {
+                            'mssql.allow_persistent': 'On',
+                            'mssql.max_persistent': -1,
+                            'mssql.max_links': -1,
+                            'mssql.min_error_severity': 10,
+                            'mssql.min_message_severity': 10,
+                            'mssql.compatibility_mode': 'Off',
+                            'mssql.secure_connection': 'Off'
+                        },
+                        'Tidy': {
+                            'tidy.clean_output': 'Off'
+                        },
+                        'soap': {
+                            'soap.wsdl_cache_enabled': 1,
+                            'soap.wsdl_cache_dir': '"/tmp"',
+                            'soap.wsdl_cache_ttl': 86400,
+                            'soap.wsdl_cache_limit': 5
+                        },
+                        'ldap': {
+                            'ldap.max_links': -1
+                        },
+                    },
+                },
+    }, merge=True) %}
 {%- else %}
     {%- set php = salt['pillar.get']('php:ng', {
         'lookup': salt['grains.filter_by']({

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -1449,7 +1449,7 @@
                             'php': 'php' + phpng_version,
                             'phpenmod_command': 'phpenmod -v' + phpng_version,
                             'pspell': 'php' + phpng_version + '-pspell',
-                            'redis': 'php' + phpng_version + '-redis',
+                            'redis': 'php-redis',
                             'seclib': ['php-phpseclib', 'php-seclib'],
                             'snmp': 'php' + phpng_version + '-snmp',
                             'soap': 'php' + phpng_version + '-soap',


### PR DESCRIPTION
Installation on Debian Jessie was not working properly with PHP7.0 packages from https://deb.sury.org/ until we changed this. The map.jinja basically seems a bit messed up, note this is not a cleanup for that file but it made things working again for us.