### PR TITLE
Make php.ng.maps.jinja work for php5 on Debian

### DIFF
--- a/php/ng/fpm/pools_config.sls
+++ b/php/ng/fpm/pools_config.sls
@@ -10,6 +10,12 @@
 {% set pool_states = [] %}
 
 {% for pool, config in php.fpm.pools.iteritems() %}
+{% if pool == 'defaults' %}{% continue %}{% endif %}
+{% for pkey, pvalues in config.get('settings', {}).iteritems() %}
+{% set pool_defaults = php.fpm.pools.get('defaults', {}).copy() %}
+  {% do pool_defaults.update(pvalues) %}
+  {% do pvalues.update(pool_defaults) %}
+{% endfor %}
 {% set state = 'php_fpm_pool_conf_' ~ loop.index0 %}
 {% set fpath = path_join(config.get('filename', pool), php.lookup.fpm.pools) %}
 

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -1400,6 +1400,11 @@
     {%- endif %}
 {%- elif salt['grains.get']('os') == "Debian" %}
     {%- set phpng_version = salt['pillar.get']('php:ng:version', '7.0')|string %}
+    {%- if phpng_version|string == '5' %}
+      {%- set confdir = '/etc/php5' %}
+    {%- else %}
+      {%- set confdir = '/etc/php/' + phpng_version %}
+    {%- endif %}
     {%- set php = salt['pillar.get']('php:ng', {
     'lookup': salt['grains.filter_by']({
                     'Debian': {
@@ -1468,16 +1473,16 @@
                             'zip': 'php' + phpng_version + '-zip',
                         },
                         'fpm': {
-                            'conf': '/etc/php/' + phpng_version + '/fpm/php-fpm.conf',
-                            'ini': '/etc/php/' + phpng_version + '/fpm/php.ini',
-                            'pools': '/etc/php/' + phpng_version + '/fpm/pool.d',
+                            'conf': confdir + '/fpm/php-fpm.conf',
+                            'ini': confdir + '/fpm/php.ini',
+                            'pools': confdir +  '/fpm/pool.d',
                             'service': 'php' + phpng_version + '-fpm',
                             'defaults': odict([
                                 ('global', odict([
                                     ('pid', '/var/run/php' + phpng_version + '-fpm.pid'),
                                     ('error_log', '/var/log/php' + phpng_version + '-fpm.log'),
                                 ])),
-                                ('include', '/etc/php/' + phpng_version + '/fpm/pool.d/*.conf'),
+                                ('include', confdir + '/fpm/pool.d/*.conf'),
                             ]),
                         },
                         'hhvm': {
@@ -1505,10 +1510,10 @@
                             ]),
                         },
                         'cli': {
-                            'ini': '/etc/php/' + phpng_version + '/cli/php.ini',
+                            'ini': confdir + '/cli/php.ini',
                         },
                         'apache2': {
-                            'ini': '/etc/php/' + phpng_version + '/apache2/php.ini',
+                            'ini': confdir + '/apache2/php.ini',
                         },
                     },
                 }),

--- a/pillar.example
+++ b/pillar.example
@@ -93,6 +93,12 @@ php:
 
       # settings for fpm-pools
       pools:
+        # defaults will apply for each pools settings and can be overwritten by pool settings
+        defaults:
+          user: nginx
+          group: nginx
+          listen: /var/run/php-fpm-default.sock
+
         # name of the pool file to be managed, this will be appended
         # to the path specified in php.ng.lookup.fpm.pools
         'mypool.conf':


### PR DESCRIPTION
Since php5 installs in different location, this formula was not working. I added an if statement to determine the correct dir.

This change only affects Debian with php5.