### PR TITLE
Do not include php state in php.fpm

### DIFF
--- a/php/fpm.sls
+++ b/php/fpm.sls
@@ -1,8 +1,5 @@
 {%- from "php/map.jinja" import php with context %}
 
-include:
-  - php
-
 php-fpm:
   pkg.installed:
     - name: {{ php.fpm_pkg }}


### PR DESCRIPTION
Including php in php.fpm makes it hard to use php fpm with webservers such as
nginx or lighttpd on, at least, Debian and derivatives.

This fixes #124.