### PR TITLE
Move state php_{{ phpng_version }}_link to cli/install.sls 

### DIFF
--- a/php/ng/cli/install.sls
+++ b/php/ng/cli/install.sls
@@ -1,2 +1,13 @@
 {% set state = 'cli' %}
 {% include "php/ng/installed.jinja" %}
+
+
+php_{{ phpng_version }}_link:
+  alternatives.set:
+    - name: php
+    - path: /usr/bin/php{{ phpng_version }}
+    - require_in:
+      - pkg: php_install_{{ state }}
+    - onlyif:
+      - which php
+      - test {{ current_php }} != $(which php{{ phpng_version }})

--- a/php/ng/installed.jinja
+++ b/php/ng/installed.jinja
@@ -47,16 +47,6 @@ php_ppa_{{ state }}:
     - onchanges:
       - pkgrepo: php_ppa_{{ state }}
 
-php_{{ phpng_version }}_link:
-  alternatives.set:
-    - name: php
-    - path: /usr/bin/php{{ phpng_version }}
-    - require_in:
-      - pkg: php_install_{{ state }}
-    - onlyif:
-      - which php
-      - test {{ current_php }} != $(which php{{ phpng_version }})
-
   {% endif %}
 {% endif %}
 


### PR DESCRIPTION
There is already the Pull-Request #119  and this PR is the alternative mentioned in the PR:

move the state from installed.jinja into cli/install.sls

I just tested this with upgrading from php5.6 to 7.1 on Ubuntu Xenial. With this Patch it works installing php.ng.fpm and php.ng.composer on the same machine :-)




