### PR TITLE
Revert "Move state php_{{ phpng_version }}_link to cli/install.sls "

### DIFF
--- a/php/ng/cli/install.sls
+++ b/php/ng/cli/install.sls
@@ -1,13 +1,2 @@
 {% set state = 'cli' %}
 {% include "php/ng/installed.jinja" %}
-
-
-php_{{ phpng_version }}_link:
-  alternatives.set:
-    - name: php
-    - path: /usr/bin/php{{ phpng_version }}
-    - require_in:
-      - pkg: php_install_{{ state }}
-    - onlyif:
-      - which php
-      - test {{ current_php }} != $(which php{{ phpng_version }})

--- a/php/ng/installed.jinja
+++ b/php/ng/installed.jinja
@@ -47,6 +47,16 @@ php_ppa_{{ state }}:
     - onchanges:
       - pkgrepo: php_ppa_{{ state }}
 
+php_{{ phpng_version }}_link:
+  alternatives.set:
+    - name: php
+    - path: /usr/bin/php{{ phpng_version }}
+    - require_in:
+      - pkg: php_install_{{ state }}
+    - onlyif:
+      - which php
+      - test {{ current_php }} != $(which php{{ phpng_version }})
+
   {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Reverts saltstack-formulas/php-formula#129

not working missing:
{% set phpng_version = salt['pillar.get']('php:ng:version', '7.0')|string %}
{% set current_php = salt['alternatives.show_current']('php') %}