### PR TITLE
Fix to be able to create the pools folder in the fpm

### DIFF
--- a/php/ng/fpm/config.sls
+++ b/php/ng/fpm/config.sls
@@ -19,3 +19,11 @@ php_fpm_ini_config:
 
 php_fpm_conf_config:
   {{ php_ini(php.lookup.fpm.conf, php.fpm.config.conf.opts, conf_settings) }}
+
+{{ php.lookup.fpm.pools }}:
+    file.directory:
+        - name: {{ php.lookup.fpm.pools }}
+        - user: root
+        - group: root
+        - file_mode: 755
+        - make_dirs: True


### PR DESCRIPTION
This is nice to be able to use the Remi Repository in RedHat family OSs because php-fpm in remi repository doesn't create the ``/etc/php-fpm.d/`` folder where the pools should be.