### PR TITLE
Changed method to detect if composer self-update is needed.

### DIFF
--- a/php/composer.sls
+++ b/php/composer.sls
@@ -32,7 +32,7 @@ install-composer:
     - require:
       - file: get-composer
 
-# Get COMPOSER_DEV_WARNING_TIME from the installed composer, and if that time has passed
+# Get composer version date and check if older than 60day (defaultvalue of COMPOSER_DEV_WARNING_TIME)
 # then it's time to run `composer selfupdate`
 #
 # It would be nice if composer had a command line switch to get this, but it doesn't,
@@ -41,7 +41,7 @@ install-composer:
 update-composer:
   cmd.run:
     - name: "{{ install_file }} selfupdate"
-    - unless: test $(grep --text COMPOSER_DEV_WARNING_TIME {{ install_file }} | egrep '^\s*define' | sed -e 's,[^[:digit:]],,g') \> $(php -r 'echo time();')
+    - unless: test $(date -d "60 days $({{ install_file }} --version | cut -d ' ' -f 4,5)" "+%s") \> $(date "+%s")
     - cwd: {{ php.local_bin }}
     - env:
       - HOME: {{ salt_user_home }}

--- a/php/ng/composer.sls
+++ b/php/ng/composer.sls
@@ -32,7 +32,7 @@ install-composer:
     - require:
       - file: get-composer
 
-# Get COMPOSER_DEV_WARNING_TIME from the installed composer, and if that time has passed
+# Get composer version date and check if older than 60day (defaultvalue of COMPOSER_DEV_WARNING_TIME)
 # then it's time to run `composer selfupdate`
 #
 # It would be nice if composer had a command line switch to get this, but it doesn't,
@@ -41,7 +41,7 @@ install-composer:
 update-composer:
   cmd.run:
     - name: "{{ install_file }} selfupdate"
-    - unless: test $(grep --text COMPOSER_DEV_WARNING_TIME {{ install_file }} | egrep '^\s*define' | sed -e 's,[^[:digit:]],,g') \> $(php -r 'echo time();')
+    - unless: test $(date -d "60 days $({{ install_file }} --version | cut -d ' ' -f 4,5)" "+%s") \> $(date "+%s")
     - cwd: {{ php.lookup.pkgs.local_bin }}
     - env:
       - HOME: {{ salt_user_home }}


### PR DESCRIPTION
Changed update-composer method to get version date from --version output of composer.
The old method always runs a update because COMPOSER_DEV_WARNING_TIME is only defined after 60days and causes test to fail condition with null value.