### PR TITLE
Remove sorting of php.ini files to support Python3

### DIFF
--- a/php/ng/files/php.ini
+++ b/php/ng/files/php.ini
@@ -5,7 +5,7 @@
 {{ section }} = {{ settings }}
             {%- else %}
 [{{ section }}]
-                {%- for setting in settings|sort -%}
+                {%- for setting in settings -%}
                     {%- for key, value in setting.items() %}
                         {%- if value is number or value is string %}
     {{ key }} = {{ value }}


### PR DESCRIPTION
As per https://github.com/saltstack/salt/issues/39009 - and the following error message:

```
          ID: php_fpm_pool_conf_0                                                                                          
    Function: file.managed                                                                                                 
        Name: /etc/php/7.2/fpm/pool.d/www.conf                                                                             
      Result: False                                                                                                        
     Comment: Unable to manage file: Jinja error: '<' not supported between instances of 'OrderedDict' and 'OrderedDict'   
              Traceback (most recent call last):                                                                           
                File "/usr/lib/python3/dist-packages/salt/utils/templates.py", line 418, in render_jinja_tmpl              
                  output = template.render(**decoded_context)                                                              
                File "/usr/lib/python3/dist-packages/jinja2/asyncsupport.py", line 76, in render                           
                  return original_render(self, *args, **kwargs)                                                            
                File "/usr/lib/python3/dist-packages/jinja2/environment.py", line 1008, in render                          
                  return self.environment.handle_exception(exc_info, True)                                                 
                File "/usr/lib/python3/dist-packages/jinja2/environment.py", line 780, in handle_exception                 
                  reraise(exc_type, exc_value, tb)                                                                         
                File "/usr/lib/python3/dist-packages/jinja2/_compat.py", line 37, in reraise                               
                  raise value.with_traceback(tb)                                                                           
                File "<template>", line 33, in top-level template code                                                     
                File "/usr/lib/python3/dist-packages/jinja2/runtime.py", line 579, in _invoke                              
                  rv = self._func(*arguments)                                                                              
                File "<template>", line 8, in template                                                                     
                File "/usr/lib/python3/dist-packages/jinja2/filters.py", line 278, in do_sort                              
                  return sorted(value, key=key_func, reverse=reverse)                                                      
              TypeError: '<' not supported between instances of 'OrderedDict' and 'OrderedDict'                            
                                                                                                                           
              ; line 8                                                                                                     
                                                                                                                           
              ---                                                                                                          
              [...]                                                                                                        
                      {%- for section, settings in sections.items() -%}                                                    
                          {%- if settings is number or settings is string %}                                               
              {{ section }} = {{ settings }}                                                                               
                          {%- else %}                                                                                      
              [{{ section }}]                                                                                              
                              {%- for setting in settings|sort -%}    <======================                              
                                  {%- for key, value in setting.items() %}
                                      {%- if value is number or value is string %}
                  {{ key }} = {{ value }}
                                      {%- elif value is iterable -%}
                                          {%- if key == 'error_reporting' %}
              [...]
```

Python3's OrderedDict does not support being sorted. I don't know exactly why the sorting was done, as far as I can tell it doesn't necessarily need to be sorted to make sense to PHP.