### PR TITLE
Handle different scl/legacy php naming for opcache.

### DIFF
--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -2738,7 +2738,7 @@
                     'net-smtp': 'php-pear-Net-SMTP',
                     'net4': 'php-pear-Net-IPv4',
                     'oauth': 'php-pecl-oauth',
-                    'opcache': 'php-pecl-zendopcache',
+                    'opcache': rh_prefix + 'php-opcache' if salt['pillar.get']('php:use_scl_repo', False) else 'php-pecl-zendopcache',
                     'pear': rh_prefix + 'php-pear',
                     'pgsql': rh_prefix + 'php-pgsql',
                     'php': rh_prefix + 'php',


### PR DESCRIPTION
When running on CentOS or RHEL the opcache package under php 5.4
us named php-pecl-zendopcache.
When using a newer PHP version like 5.6, 7.0 or 7.1 the package
is named slightly different though: php-opcache.

Take this into account.