### PR TITLE
Fix/fpm freebsd

### DIFF
--- a/php/ng/fpm/config.sls
+++ b/php/ng/fpm/config.sls
@@ -23,7 +23,7 @@ php_fpm_conf_config:
 {{ php.lookup.fpm.pools }}:
     file.directory:
         - name: {{ php.lookup.fpm.pools }}
-        - user: root
-        - group: root
+        - user: {{ php.lookup.fpm.user }}
+        - group: {{ php.lookup.fpm.group }}
         - file_mode: 755
         - make_dirs: True

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -84,6 +84,8 @@
                             'ini': '/etc/php/' + phpng_version + '/fpm/php.ini',
                             'pools': '/etc/php/' + phpng_version + '/fpm/pool.d',
                             'service': 'php' + phpng_version + '-fpm',
+                            'user': 'root',
+                            'group': 'root',
                             'defaults': odict([
                                 ('global', odict([
                                     ('pid', '/var/run/php' + phpng_version + '-fpm.pid'),
@@ -125,8 +127,6 @@
                     },
                 }),
                 'fpm': {
-                    'user': 'root',
-                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -411,6 +411,8 @@
                             'ini': '/etc/php/' + phpng_version + '/fpm/php.ini',
                             'pools': '/etc/php/' + phpng_version + '/fpm/pool.d',
                             'service': 'php' + phpng_version + '-fpm',
+                            'user': 'root',
+                            'group': 'root',
                             'defaults': odict([
                                 ('global', odict([
                                     ('pid', '/var/run/php' + phpng_version + '-fpm.pid'),
@@ -452,8 +454,6 @@
                     },
                 }),
                 'fpm': {
-                    'user': 'root',
-                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -732,6 +732,8 @@
                             'ini': '/etc/php/7.2/fpm/php.ini',
                             'pools': '/etc/php/7.2/fpm/pool.d',
                             'service': 'php7.2-fpm',
+                            'user': 'root',
+                            'group': 'root',
                             'defaults': odict([
                                 ('global', odict([
                                     ('pid', '/var/run/php7.2-fpm.pid'),
@@ -777,8 +779,6 @@
                     },
                 }, grain="os"),
                 'fpm': {
-                    'user': 'root',
-                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -1104,6 +1104,8 @@
                             'ini': '/etc/php/7.1/fpm/php.ini',
                             'pools': '/etc/php/7.1/fpm/pool.d',
                             'service': 'php7.1-fpm',
+                            'user': 'root',
+                            'group': 'root',
                             'defaults': odict([
                                 ('global', odict([
                                     ('pid', '/var/run/php7.1-fpm.pid'),
@@ -1149,8 +1151,6 @@
                     },
                 }, grain="os"),
                 'fpm': {
-                    'user': 'root',
-                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -1476,6 +1476,8 @@
                             'ini': '/etc/php/7.0/fpm/php.ini',
                             'pools': '/etc/php/7.0/fpm/pool.d',
                             'service': 'php7.0-fpm',
+                            'user': 'root',
+                            'group': 'root',
                             'defaults': odict([
                                 ('global', odict([
                                     ('pid', '/var/run/php7.0-fpm.pid'),
@@ -1521,8 +1523,6 @@
                     },
                 }, grain="os"),
                 'fpm': {
-                    'user': 'root',
-                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -1867,6 +1867,8 @@
                             'ini': '/etc/php5/fpm/php.ini',
                             'pools': '/etc/php5/fpm/pool.d',
                             'service': 'php5-fpm',
+                            'user': 'root',
+                            'group': 'root',
                             'defaults': odict([
                                 ('global', odict([
                                     ('pid', '/var/run/php5-fpm.pid'),
@@ -1912,8 +1914,6 @@
                     },
                 }, grain="os"),
                 'fpm': {
-                    'user': 'root',
-                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -2253,6 +2253,8 @@
                             'ini': confdir + '/fpm/php.ini',
                             'pools': confdir +  '/fpm/pool.d',
                             'service': 'php' + phpng_version + '-fpm',
+                            'user': 'root',
+                            'group': 'root',
                             'defaults': odict([
                                 ('global', odict([
                                     ('pid', '/var/run/php' + phpng_version + '-fpm.pid'),
@@ -2294,8 +2296,6 @@
                     },
                 }),
                 'fpm': {
-                    'user': 'root',
-                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -2915,6 +2915,7 @@
                     'curl': 'php' + freebsd_phpng_version + '-curl',
                     'filter': 'php' + freebsd_phpng_version + '-filter',
                     'fileinfo': 'php' + freebsd_phpng_version + '-fileinfo',
+                    'fpm': 'php' + freebsd_phpng_version,
                     'gd': 'php' + freebsd_phpng_version + '-gd',
                     'hash': 'php' + freebsd_phpng_version + '-hash',
                     'json': 'php' + freebsd_phpng_version + '-json',

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -125,6 +125,8 @@
                     },
                 }),
                 'fpm': {
+                    'user': 'root',
+                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -450,6 +452,8 @@
                     },
                 }),
                 'fpm': {
+                    'user': 'root',
+                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -773,6 +777,8 @@
                     },
                 }, grain="os"),
                 'fpm': {
+                    'user': 'root',
+                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -1143,6 +1149,8 @@
                     },
                 }, grain="os"),
                 'fpm': {
+                    'user': 'root',
+                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -1513,6 +1521,8 @@
                     },
                 }, grain="os"),
                 'fpm': {
+                    'user': 'root',
+                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -1902,6 +1912,8 @@
                     },
                 }, grain="os"),
                 'fpm': {
+                    'user': 'root',
+                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -2282,6 +2294,8 @@
                     },
                 }),
                 'fpm': {
+                    'user': 'root',
+                    'group': 'root',
                     'service': {
                         'enabled': True,
                         'opts': {},
@@ -2581,6 +2595,8 @@
                     'ini': '/etc/php5/fpm/php.ini',
                     'pools': '/etc/php5/fpm/pool.d',
                     'service': 'php5-fpm',
+                    'user': 'root',
+                    'group': 'root',
                     'defaults': odict([
                         ('global', odict([
                             ('pid', '/var/run/php5-fpm.pid'),
@@ -2684,6 +2700,8 @@
                     'ini': '/etc/php/fpm-php' + phpng_version + '/php.ini',
                     'pools': '/etc/php/fpm-php' + phpng_version + '/fpm.d',
                     'service': 'php-fpm',
+                    'user': 'root',
+                    'group': 'root',
                     'defaults': odict([
                         ('global', odict([
                             ('pid', '/var/run/php-fpm-php' + phpng_version + '.pid'),
@@ -2768,6 +2786,8 @@
                     'ini': '/etc/' + path_suffix + 'php.ini',
                     'pools': '/etc/' + path_suffix + 'php-fpm.d',
                     'service': rh_prefix + 'php-fpm',
+                    'user': 'root',
+                    'group': 'root',
                     'defaults': {
                         'global': {
                             'pid': '/var/' + path_suffix + 'run/php-fpm/php-fpm.pid',
@@ -2814,6 +2834,8 @@
                     'ini': '/etc/php.ini',
                     'pools': '/etc/php-fpm.d',
                     'service': 'php-fpm',
+                    'user': 'root',
+                    'group': 'root',
                     'defaults': {
                         'global': {
                             'pid': '/var/run/php-fpm/php-fpm.pid',
@@ -2859,6 +2881,8 @@
                     'ini': '/etc/php/php.ini',
                     'pools': '/etc/php/fpm.d',
                     'service': 'php-fpm',
+                    'user': 'root',
+                    'group': 'root',
                     'defaults': {
                         'global': {
                             'pid': '/run/php-fpm/php-fpm.pid',
@@ -2908,6 +2932,21 @@
                     'tokenizer': 'php' + freebsd_phpng_version + '-tokenizer',
                     'xml': 'php' + freebsd_phpng_version + '-xml',
                     'zip': 'php' + freebsd_phpng_version + '-zip',
+                },
+                'fpm': {
+                    'conf': '/usr/local/etc/php-fpm.conf',
+                    'ini': '/usr/local/etc/php.ini',
+                    'pools': '/usr/local/etc/fpm.d',
+                    'service': 'php-fpm',
+                    'user': 'root',
+                    'group': 'wheel',
+                    'defaults': {
+                        'global': {
+                            'pid': 'run/php-fpm.pid',
+                            'error_log': 'log/php-fpm.log',
+                        },
+                        'include': '/usr/local/etc/php-fpm.d/*.conf',
+                    },
                 },
             },
         }),

--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -2937,7 +2937,7 @@
                 'fpm': {
                     'conf': '/usr/local/etc/php-fpm.conf',
                     'ini': '/usr/local/etc/php.ini',
-                    'pools': '/usr/local/etc/fpm.d',
+                    'pools': '/usr/local/etc/php-fpm.d',
                     'service': 'php-fpm',
                     'user': 'root',
                     'group': 'wheel',


### PR DESCRIPTION
Add minimum default to get nginx.ng.fpm state works on FreeBSD
- replaced user and group of pool directory by vars lookup in map.jinja
- default user/group added for all other OS to don't produce breaking changes
- added fpm default conf for Freebsd
- Tested on FreeBSD and Debian with a custom pool placed in pillar