### PR TITLE
Remove env from ppa definition

### DIFF
--- a/php/ng/installed.jinja
+++ b/php/ng/installed.jinja
@@ -31,7 +31,7 @@
 php_ppa_{{ state }}:
   pkgrepo.managed:
     - ppa: {{ external_repo_name }}
-    - env:
+    - __env__:
       - LC_ALL: C.UTF-8
     - onlyif:
       - test ! -e /etc/apt/sources.list.d/ondrej-ubuntu-php-{{ grains['oscodename'] }}.list {# Trusty and Xenial use different naming schemas #}
@@ -57,7 +57,7 @@ php_ppa_{{ state }}:
     - name: deb https://packages.sury.org/php/ {{ grains['oscodename'] }} main
     - file: /etc/apt/sources.list.d/ondrej-php.list
     - key_url: https://packages.sury.org/php/apt.gpg
-    - env:
+    - __env__:
       - LC_ALL: C.UTF-8
     - onlyif:
       - test ! -e /etc/apt/sources.list.d/ondrej-php.list 


### PR DESCRIPTION
Using the latest version of this repo on Ubuntu 18.04 and installing php.ng with the ppa enabled and php 7.3 as target, I get the following:

```
          ID: php_ppa_fpm
    Function: pkgrepo.managed
      Result: False
     Comment: Failed to configure repo 'php_ppa_fpm': _call_apt() got multiple values for keyword argument 'env'
     Started: 12:30:59.229400
    Duration: 72.24 ms
     Changes:
```

![image](https://user-images.githubusercontent.com/183678/53959867-1aa1a380-40e5-11e9-9ffb-f29f953f5cf4.png)

I am not sure what causes this, I dug in salt source a bit but couldn't figure it out. Renaming to __env__ or removing the env entirely both make it work. 
