### PR TITLE
Fix "Invalidly formatted 'pkgs' parameter." error with php-readline

### DIFF
--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -2231,6 +2231,7 @@
                             'php': 'php' + phpng_version,
                             'phpenmod_command': 'phpenmod -v' + phpng_version,
                             'pspell': 'php' + phpng_version + '-pspell',
+                            'readline': 'php' + phpng_version + '-readline',
                             'redis': 'php-redis',
                             'seclib': ['php-phpseclib', 'php-seclib'],
                             'snmp': 'php' + phpng_version + '-snmp',


### PR DESCRIPTION
Hi!

This PR fixes "Invalidly formatted 'pkgs' parameter." error with php-readline.

Thank you!