### PR TITLE
fpm: don't extend pool-dependency if no pool

### DIFF
--- a/php/ng/fpm/pools.sls
+++ b/php/ng/fpm/pools.sls
@@ -13,10 +13,12 @@ include:
   - php.ng.fpm.service
   - php.ng.fpm.pools_config
 
+{% if pool_states %}
 extend:
   php_fpm_service:
     service:
       - watch:
-        {{ file_requisites(pool_states) }}
+{{ file_requisites(pool_states) }}
       - require:
-        {{ file_requisites(pool_states) }}
+{{ file_requisites(pool_states) }}
+{% endif %}


### PR DESCRIPTION
Calling `php.ng.fpm.pools` (included by `php.ng.fpm`) fails when there is no pool.

Fix, by not trying to extend if we have nothing to add.