### PR TITLE
php.ng.modules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -502,6 +502,13 @@ Disabled on opensuse need server:php:extensions repo
 Installs the php-memcached package.
 Disabled on opensuse need server:php:extensions repo
 
+``php.ng.module``
+--------------------
+
+Calls ``php.ng.<name>`` for each entry in ``php:ng:modules`` if available, or
+try to install the matching packages that can be set via from
+``php:ng:lookup:pkgs``
+
 ``php.ng.mongo``
 --------------------
 

--- a/php/ng/modules.sls
+++ b/php/ng/modules.sls
@@ -1,0 +1,23 @@
+{% from "php/ng/map.jinja" import php with context %}
+
+{% set modules = salt['pillar.get']('php:ng:modules') or [] %}
+{% set base_name = 'php.ng.' %}
+{% set existing_states = salt['cp.list_states']() %}
+
+{% set includes = [] %}
+{% set install = [] %}
+
+{% for module in modules %}
+{%   set state = base_name + module %}
+{%   if state in existing_states %}
+{%     do includes.append(state) %}
+{%   else %}
+{%     do install.append(module) %}
+{%   endif %}
+{% endfor %}
+
+include: {{ includes|json }}
+
+{% for state in install %}
+{%   include "php/ng/installed.jinja" %}
+{% endfor %}

--- a/php/ng/modules.sls
+++ b/php/ng/modules.sls
@@ -8,7 +8,7 @@
 {% set install = [] %}
 
 {% for module in modules %}
-{%   set state = base_name + module %}
+{%   set state = base_name ~ module %}
 {%   if state in existing_states %}
 {%     do includes.append(state) %}
 {%   else %}

--- a/pillar.example
+++ b/pillar.example
@@ -178,6 +178,15 @@ php:
         'CLI Server':
           cli_server_color: 'On'
 
+    # List of modules to install via php.ng.modules
+    modules:
+      # Calls `php.ng.<name>` if available, or try to install the matching
+      # packages that can be set via from php:ng:lookup:pkgs
+      - cli
+      - fpm
+      - curl
+      - mysql
+
     # When using php.ng.apache2 on FreeBSD:
     # Set this to False if you're not using apache-formula
     use_apache_formula: True


### PR DESCRIPTION
Support `php.ng.modules` to call and install pillar-listed modules.

Either call the matching `php.ng.xxx` or directly the package from lookup.