### PR TITLE
fix: warn formula users ng states will be promoted in `v1.0.0`

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -16,6 +16,31 @@ php-formula
 
 Formula to set up and configure php
 
+.. list-table::
+   :name: banner-breaking-changes-v1.0.0
+   :header-rows: 1
+   :widths: 1
+
+   * - WARNING: BREAKING CHANGES IN UPCOMING ``v1.0.0``
+   * - This formula currently provides two methods for managing PHP; the old method
+       under ``php`` and the new method under ``php.ng``.
+       In upcoming `v1.0.0 <https://github.com/saltstack-formulas/php-formula/releases/tag/v1.0.0>`_,
+       the old method will be removed and ``php.ng`` will be promoted to ``php`` in its place.
+
+       If you are not in a position to migrate, you will need to pin your repo to
+       the final release tag before
+       `v1.0.0 <https://github.com/saltstack-formulas/php-formula/releases/tag/v1.0.0>`_,
+       which is expected to be
+       `v0.37.1 <https://github.com/saltstack-formulas/php-formula/releases/tag/v0.37.1>`_.
+
+       If you are currently using ``php.ng``, there is nothing to do until
+       `v1.0.0 <https://github.com/saltstack-formulas/php-formula/releases/tag/v1.0.0>`_
+       is released.
+
+       To migrate from the old ``php``, the first step is to convert to ``php.ng``,
+       before `v1.0.0 <https://github.com/saltstack-formulas/php-formula/releases/tag/v1.0.0>`_
+       is released.
+
 .. contents:: **Table of Contents**
 
 General notes

--- a/php/adodb.sls
+++ b/php/adodb.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-adodb:

--- a/php/apc.sls
+++ b/php/apc.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-apc:

--- a/php/apcu.sls
+++ b/php/apcu.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-apcu:

--- a/php/bcmath.sls
+++ b/php/bcmath.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-bcmath:

--- a/php/cgi.sls
+++ b/php/cgi.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-cgi:

--- a/php/cli.sls
+++ b/php/cli.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-cli:

--- a/php/composer.sls
+++ b/php/composer.sls
@@ -11,6 +11,7 @@
 {%- set salt_user_home = salt['user.info'](salt_user).get('home', '/root') %}
 
 include:
+  - php.deprecated
   - php
 
 get-composer:

--- a/php/curl.sls
+++ b/php/curl.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-curl:

--- a/php/deprecated.sls
+++ b/php/deprecated.sls
@@ -1,30 +1,29 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
-php-deprecated-in-v1.0.0-test-fail:
+php-deprecated-in-v1.0.0-test-succeed:
   test.succeed_without_changes:
     - name: |
+
+
         ################################################################################
         #                                                                              #
-        #                   WARNING: BREAKING CHANGES SINCE `v1.0.0`                   #
+        #            WARNING: BREAKING CHANGES IN UPCOMING VERSION `v1.0.0`            #
         #                                                                              #
         ################################################################################
         #                                                                              #
-        # Prior to `v1.0.0`, this formula provided two methods for managing php; the   #
-        # old method under `php` and the new method under `php.ng`. The old method     #
-        # has now been removed and `php.ng` has been promoted to be `PHP` in its       #
-        # place.                                                                       #
+        # This formula currently provides two methods for managing PHP; the old method #
+        # under `php` and the new method under `php.ng`. In upcoming `v1.0.0`, the old #
+        # method will be removed and `php.ng` will be promoted to `php` in its place.  #
         #                                                                              #
-        # If you are not in a position to migrate, please pin your repo to the final   #
-        # release tag before `v1.0.0`, i.e. `v0.37.1`.                                 #
+        # If you are not in a position to migrate, you will need to pin your repo to   #
+        # the final release tag before `v1.0.0`, which is expected to be `v0.37.1`.    #
         #                                                                              #
-        # To migrate from `php.ng`, simply modify your pillar to promote the entire    #
-        # section under `php:ng` so that it is under `php` instead. So with the        #
-        # editor of your choice, highlight the entire section and then unindent one    #
-        # level. Finish by removing the `ng:` line.                                    #
+        # If you are currently using `php.ng`, there is nothing to do until `v1.0.0`   #
+        # is released.                                                                 #
         #                                                                              #
-        # To migrate from the old `php`, first convert to `php.ng` under `v0.37.0`     #
-        # and then follow the steps laid out in the paragraph directly above.          #
+        # To migrate from the old `php`, the first step is to convert to `php.ng`,     #
+        # before `v1.0.0` is released.                                                 #
         #                                                                              #
         ################################################################################
     # - failhard: True

--- a/php/deprecated.sls
+++ b/php/deprecated.sls
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
+{#- Evaluating as `False` by default, using this method since `defaults.yaml` not available in this repo #}
+{%- if not salt['config.get']('php').get('warning_messages', {}).get('v1.0.0', {}).get('mute_critical', False) %}
 php-deprecated-in-v1.0.0-test-succeed:
   test.succeed_without_changes:
     - name: |
@@ -25,5 +27,15 @@ php-deprecated-in-v1.0.0-test-succeed:
         # To migrate from the old `php`, the first step is to convert to `php.ng`,     #
         # before `v1.0.0` is released.                                                 #
         #                                                                              #
+        # To prevent this message being displayed again, set the pillar/config value:  #
+        #                                                                              #
+        # ```                                                                          #
+        # php:                                                                         #
+        #   warning_messages:                                                          #
+        #     v1.0.0:                                                                  #
+        #       mute_critical: True                                                    #
+        # ```                                                                          #
+        #                                                                              #
         ################################################################################
     # - failhard: True
+{%- endif %}

--- a/php/deprecated.sls
+++ b/php/deprecated.sls
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+php-deprecated-in-v1.0.0-test-fail:
+  test.succeed_without_changes:
+    - name: |
+        ################################################################################
+        #                                                                              #
+        #                   WARNING: BREAKING CHANGES SINCE `v1.0.0`                   #
+        #                                                                              #
+        ################################################################################
+        #                                                                              #
+        # Prior to `v1.0.0`, this formula provided two methods for managing php; the   #
+        # old method under `php` and the new method under `php.ng`. The old method     #
+        # has now been removed and `php.ng` has been promoted to be `PHP` in its       #
+        # place.                                                                       #
+        #                                                                              #
+        # If you are not in a position to migrate, please pin your repo to the final   #
+        # release tag before `v1.0.0`, i.e. `v0.37.1`.                                 #
+        #                                                                              #
+        # To migrate from `php.ng`, simply modify your pillar to promote the entire    #
+        # section under `php:ng` so that it is under `php` instead. So with the        #
+        # editor of your choice, highlight the entire section and then unindent one    #
+        # level. Finish by removing the `ng:` line.                                    #
+        #                                                                              #
+        # To migrate from the old `php`, first convert to `php.ng` under `v0.37.0`     #
+        # and then follow the steps laid out in the paragraph directly above.          #
+        #                                                                              #
+        ################################################################################
+    # - failhard: True

--- a/php/dev.sls
+++ b/php/dev.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-dev:

--- a/php/fpm.sls
+++ b/php/fpm.sls
@@ -1,5 +1,8 @@
 {%- from "php/map.jinja" import php with context %}
 
+include:
+  - php.deprecated
+
 php-fpm:
   pkg.installed:
     - name: {{ php.fpm_pkg }}

--- a/php/gd.sls
+++ b/php/gd.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-gd:

--- a/php/imagick.sls
+++ b/php/imagick.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-imagick:

--- a/php/imap.sls
+++ b/php/imap.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-imap:

--- a/php/init.sls
+++ b/php/init.sls
@@ -1,5 +1,8 @@
 {%- from "php/map.jinja" import php with context %}
 
+include:
+  - php.deprecated
+
 {%- if not 'ng' in salt['pillar.get']('php', {}) %}
 
   {%- if grains['os'] == "Ubuntu" %}

--- a/php/intl.sls
+++ b/php/intl.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-intl:

--- a/php/json.sls
+++ b/php/json.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-json:

--- a/php/ldap.sls
+++ b/php/ldap.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-ldap:

--- a/php/mail.sls
+++ b/php/mail.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-mail:

--- a/php/mbstring.sls
+++ b/php/mbstring.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-mbstring:

--- a/php/mcrypt.sls
+++ b/php/mcrypt.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-mcrypt:

--- a/php/memcache.sls
+++ b/php/memcache.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-memcache:

--- a/php/memcached.sls
+++ b/php/memcached.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-memcached:

--- a/php/mongo.sls
+++ b/php/mongo.sls
@@ -3,6 +3,7 @@
 {%- set version = salt['pillar.get']('php:mongo_version', none) %}
 
 include:
+  - php.deprecated
   - php
   - php.xml
   - php.dev

--- a/php/mysql.sls
+++ b/php/mysql.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-mysql:

--- a/php/mysqlnd.sls
+++ b/php/mysqlnd.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-mysqlnd:

--- a/php/ng/apache2/ini.sls
+++ b/php/ng/apache2/ini.sls
@@ -5,5 +5,8 @@
 {% set settings = php.ini.defaults %}
 {% do settings.update(php.apache2.ini.settings) %}
 
+include:
+  - php.ng.deprecated
+
 php_apache2_ini:
   {{ php_ini(php.lookup.apache2.ini, php.apache2.ini.opts, settings) }}

--- a/php/ng/apache2/init.sls
+++ b/php/ng/apache2/init.sls
@@ -1,5 +1,6 @@
 {% if grains['os_family'] in ["Debian", "FreeBSD"] %}
 include:
+  - php.ng.deprecated
   - php.ng.apache2.install
 {% endif %} #END: os = Debian|FreeBSD
 {% if grains['os_family'] == "Debian" %}

--- a/php/ng/apache2/install.sls
+++ b/php/ng/apache2/install.sls
@@ -1,5 +1,8 @@
 {% from "php/ng/map.jinja" import php with context %}
 
+include:
+  - php.ng.deprecated
+
 {% set state = 'apache2' %}
 {% include "php/ng/installed.jinja" %}
 

--- a/php/ng/cli/ini.sls
+++ b/php/ng/cli/ini.sls
@@ -2,6 +2,9 @@
 {% from "php/ng/map.jinja" import php with context %}
 {% from "php/ng/ini.jinja" import php_ini %}
 
+include:
+  - php.ng.deprecated
+
 {% set settings = php.ini.defaults %}
 {% for key, value in php.cli.ini.settings.items() %}
   {% if settings[key] is defined %}

--- a/php/ng/cli/init.sls
+++ b/php/ng/cli/init.sls
@@ -1,6 +1,7 @@
 # Installs php-cli and manages the associated php.ini
 
 include:
+  - php.ng.deprecated
   - php.ng.cli.install
   - php.ng.cli.ini
 

--- a/php/ng/cli/install.sls
+++ b/php/ng/cli/install.sls
@@ -1,6 +1,9 @@
 {% set state = 'cli' %}
 {% include "php/ng/installed.jinja" %}
 
+include:
+  - php.ng.deprecated
+
 {%- if salt['grains.get']('os_family') == "Debian" %}
 {% set current_php = salt['alternatives.show_current']('php') %}
 {% set phpng_version = salt['pillar.get']('php:ng:version', '7.0')|string %}

--- a/php/ng/composer.sls
+++ b/php/ng/composer.sls
@@ -11,6 +11,7 @@
 {% set salt_user_home = salt['user.info'](salt_user).get('home', '/root') %}
 
 include:
+  - php.ng.deprecated
   - php.ng
 {% if grains['os_family'] == 'FreeBSD' %}
   - php.ng.filter

--- a/php/ng/deprecated.sls
+++ b/php/ng/deprecated.sls
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{#- Evaluating as `False` by default, using this method since `defaults.yaml` not available in this repo #}
+{%- if not salt['config.get']('php').get('warning_messages', {}).get('v1.0.0', {}).get('mute_upcoming', False) %}
+php-deprecated-in-v1.0.0-test-succeed:
+  test.succeed_without_changes:
+    - name: |
+
+
+        ################################################################################
+        #                                                                              #
+        #            WARNING: BREAKING CHANGES IN UPCOMING VERSION `v1.0.0`            #
+        #                                                                              #
+        ################################################################################
+        #                                                                              #
+        # This formula currently provides two methods for managing PHP; the old method #
+        # under `php` and the new method under `php.ng`. In upcoming `v1.0.0`, the old #
+        # method will be removed and `php.ng` will be promoted to `php` in its place.  #
+        #                                                                              #
+        # If you are not in a position to migrate, you will need to pin your repo to   #
+        # the final release tag before `v1.0.0`, which is expected to be `v0.37.1`.    #
+        #                                                                              #
+        # If you are currently using `php.ng`, there is nothing to do until `v1.0.0`   #
+        # is released.                                                                 #
+        #                                                                              #
+        # To migrate from the old `php`, the first step is to convert to `php.ng`,     #
+        # before `v1.0.0` is released.                                                 #
+        #                                                                              #
+        # To prevent this message being displayed again, set the pillar/config value:  #
+        #                                                                              #
+        # ```                                                                          #
+        # php:                                                                         #
+        #   warning_messages:                                                          #
+        #     v1.0.0:                                                                  #
+        #       mute_upcoming: True                                                    #
+        # ```                                                                          #
+        #                                                                              #
+        ################################################################################
+{%- endif %}

--- a/php/ng/fpm/config.sls
+++ b/php/ng/fpm/config.sls
@@ -2,6 +2,9 @@
 {% from 'php/ng/map.jinja' import php with context %}
 {% from "php/ng/ini.jinja" import php_ini %}
 
+include:
+  - php.ng.deprecated
+
 {% set ini_settings = php.ini.defaults %}
 {% for key, value in php.fpm.config.ini.settings.items() %}
   {% if ini_settings[key] is defined %}

--- a/php/ng/fpm/init.sls
+++ b/php/ng/fpm/init.sls
@@ -1,6 +1,7 @@
 # Meta-state to fully install php.fpm
 
 include:
+  - php.ng.deprecated
   - php.ng.fpm.config
   - php.ng.fpm.service
   - php.ng.fpm.pools

--- a/php/ng/fpm/install.sls
+++ b/php/ng/fpm/install.sls
@@ -1,2 +1,5 @@
+include:
+  - php.ng.deprecated
+
 {% set state = 'fpm' %}
 {% include "php/ng/installed.jinja" %}

--- a/php/ng/fpm/pools.sls
+++ b/php/ng/fpm/pools.sls
@@ -10,6 +10,7 @@
 {% endmacro %}
 
 include:
+  - php.ng.deprecated
   - php.ng.fpm.service
   - php.ng.fpm.pools_config
 

--- a/php/ng/fpm/pools_config.sls
+++ b/php/ng/fpm/pools_config.sls
@@ -2,6 +2,9 @@
 {% from 'php/ng/map.jinja' import php with context %}
 {% from "php/ng/macro.jinja" import sls_block, serialize %}
 
+include:
+  - php.ng.deprecated
+
 # Simple path concatenation.
 {% macro path_join(file, root) -%}
   {{ root ~ '/' ~ file }}

--- a/php/ng/fpm/service.sls
+++ b/php/ng/fpm/service.sls
@@ -5,6 +5,7 @@
 {% set service_function = {True:'running', False:'dead'}.get(php.fpm.service.enabled) %}
 
 include:
+  - php.ng.deprecated
   - php.ng.fpm.install
 
 php_fpm_service:

--- a/php/ng/hhvm/config.sls
+++ b/php/ng/hhvm/config.sls
@@ -2,6 +2,9 @@
 {% from "php/ng/map.jinja" import php with context %}
 {% from "php/ng/ini.jinja" import php_ini %}
 
+include:
+  - php.ng.deprecated
+
 {% set server_settings = php.lookup.hhvm.server %}
 {% do server_settings.update(php.hhvm.config.server.settings) %}
 

--- a/php/ng/hhvm/init.sls
+++ b/php/ng/hhvm/init.sls
@@ -1,6 +1,7 @@
 # Meta-state to fully install php.hhvm
 
 include:
+  - php.ng.deprecated
   - php.ng.hhvm.repo
   - php.ng.hhvm.config
   - php.ng.hhvm.service

--- a/php/ng/hhvm/install.sls
+++ b/php/ng/hhvm/install.sls
@@ -1,2 +1,5 @@
+include:
+  - php.ng.deprecated
+
 {% set state = 'hhvm' %}
 {% include "php/ng/installed.jinja" %}

--- a/php/ng/hhvm/repo.sls
+++ b/php/ng/hhvm/repo.sls
@@ -2,6 +2,7 @@
 {% from "php/ng/map.jinja" import php with context %}
 
 include:
+  - php.ng.deprecated
   - php.ng.hhvm.install
 
 

--- a/php/ng/hhvm/service.sls
+++ b/php/ng/hhvm/service.sls
@@ -5,6 +5,7 @@
 {% set service_function = {True:'running', False:'dead'}.get(php.hhvm.service.enabled) %}
 
 include:
+  - php.ng.deprecated
   - php.ng.hhvm.install
 
 php_hhvm_service:
@@ -15,5 +16,5 @@ php_hhvm_service:
   - require:
     - sls: php.ng.hhvm.install
   - watch:
-    - pkg: php_install_hhvm 
+    - pkg: php_install_hhvm
 

--- a/php/ng/installed.jinja
+++ b/php/ng/installed.jinja
@@ -4,6 +4,8 @@
 {% from "php/ng/map.jinja" import php with context %}
 {% from "php/ng/macro.jinja" import sls_block %}
 
+include:
+  - php.ng.deprecated
 
 {% set pkginfo = php.lookup.pkgs.get(state) %}
 
@@ -60,7 +62,7 @@ php_ppa_{{ state }}:
     - __env__:
       - LC_ALL: C.UTF-8
     - onlyif:
-      - test ! -e /etc/apt/sources.list.d/ondrej-php.list 
+      - test ! -e /etc/apt/sources.list.d/ondrej-php.list
     - require_in:
       - pkg: php_install_{{ state }}
   pkg.latest:

--- a/php/ng/mdb2/init.sls
+++ b/php/ng/mdb2/init.sls
@@ -1,2 +1,5 @@
+include:
+  - php.ng.deprecated
+
 {% set state = 'mdb2' %}
 {% include "php/ng/installed.jinja" %}

--- a/php/ng/mdb2/mysql.sls
+++ b/php/ng/mdb2/mysql.sls
@@ -1,3 +1,6 @@
+include:
+  - php.ng.deprecated
+
 {% set state = 'mdb2-driver-mysql' %}
 {% include "php/ng/installed.jinja" %}
 {% include "php/ng/mdb2/init.sls" %}

--- a/php/ng/mdb2/pgsql.sls
+++ b/php/ng/mdb2/pgsql.sls
@@ -1,3 +1,6 @@
+include:
+  - php.ng.deprecated
+
 {% set state = 'mdb2-driver-pgsql' %}
 {% include "php/ng/installed.jinja" %}
 {% include "php/ng/mdb2/init.sls" %}

--- a/php/ng/suhosin.sls
+++ b/php/ng/suhosin.sls
@@ -1,6 +1,7 @@
 {% from "php/ng/map.jinja" import php with context %}
 
 include:
+  - php.ng.deprecated
   - php.ng
   - php.ng.dev
 

--- a/php/ng/xcache/ini.sls
+++ b/php/ng/xcache/ini.sls
@@ -2,6 +2,9 @@
 {% from "php/ng/map.jinja" import php with context %}
 {% from "php/ng/ini.jinja" import php_ini %}
 
+include:
+  - php.ng.deprecated
+
 {% set settings = php.xcache.ini.defaults %}
 {% for key, value in php.xcache.ini.settings.items() %}
   {% if settings[key] is defined %}

--- a/php/ng/xcache/init.sls
+++ b/php/ng/xcache/init.sls
@@ -1,6 +1,7 @@
 # Installs php-xcache and manages the associated xcache.ini
 
 include:
+  - php.ng.deprecated
   - php.ng.xcache.install
   - php.ng.xcache.ini
 

--- a/php/ng/xcache/install.sls
+++ b/php/ng/xcache/install.sls
@@ -1,2 +1,5 @@
+include:
+  - php.ng.deprecated
+
 {% set state = 'xcache' %}
 {% include "php/ng/installed.jinja" %}

--- a/php/oauth.sls
+++ b/php/oauth.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-oauth:

--- a/php/pear.sls
+++ b/php/pear.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-pear:

--- a/php/pgsql.sls
+++ b/php/pgsql.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-pgsql:

--- a/php/readline.sls
+++ b/php/readline.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-readline:

--- a/php/redis.sls
+++ b/php/redis.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-redis:

--- a/php/soap.sls
+++ b/php/soap.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-soap:

--- a/php/sqlite.sls
+++ b/php/sqlite.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-sqlite:

--- a/php/suhosin.sls
+++ b/php/suhosin.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
   - php.dev
 

--- a/php/sybase.sls
+++ b/php/sybase.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-sybase:

--- a/php/xml.sls
+++ b/php/xml.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-xml:

--- a/php/zip.sls
+++ b/php/zip.sls
@@ -1,6 +1,7 @@
 {%- from "php/map.jinja" import php with context %}
 
 include:
+  - php.deprecated
   - php
 
 php-zip:

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,10 @@
 ## php.ng pillar examples
 
 php:
+  # Use the following values to mute deprecation warnings
+  warning_messages:                                                          #
+    v1.0.0:                                                                  #
+      mute_critical: True                                                    #
   # Use external repository instead the default (only Ubuntu family)
   use_external_repo: True
   # Set the external repository name (valid only if use_external_repo is not none)

--- a/pillar.example
+++ b/pillar.example
@@ -5,6 +5,7 @@ php:
   warning_messages:                                                          #
     v1.0.0:                                                                  #
       mute_critical: True                                                    #
+      mute_upcoming: True                                                    #
   # Use external repository instead the default (only Ubuntu family)
   use_external_repo: True
   # Set the external repository name (valid only if use_external_repo is not none)

--- a/test/salt/pillar/debian.sls
+++ b/test/salt/pillar/debian.sls
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+php: {}

--- a/test/salt/pillar/redhat.sls
+++ b/test/salt/pillar/redhat.sls
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+php: {}

--- a/test/salt/pillar/suse.sls
+++ b/test/salt/pillar/suse.sls
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+php: {}


### PR DESCRIPTION
Deprecation Warning when using non-ng states with this php-formula.

@myii @n-rodriguez @daks
Is `v0.37.1` will be the correct release number for the warning message in `php.deprecated.sls` ?