### PR TITLE
chore: use `semantic-release` cross-formula standard structure

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -119,27 +119,8 @@ verifier:
 
 suites:
   - name: default
-    excludes:
-      - debian-9-develop-py3
-      - ubuntu-1804-develop-py3
-      - centos-7-develop-py3
-      - fedora-29-develop-py3
-      - opensuse-leap-15-develop-py3
-      - debian-9-2019-2-py3
-      - ubuntu-1804-2019-2-py3
-      - centos-7-2019-2-py3
-      - fedora-29-2019-2-py3
-      - opensuse-leap-15-2019-2-py3
-      - debian-9-2018-3-py2
-      - ubuntu-1604-2018-3-py2
-      - centos-7-2018-3-py2
-      - fedora-29-2018-3-py2
-      - opensuse-leap-42-2018-3-py2
-      - debian-8-2017-7-py2
-      - ubuntu-1604-2017-7-py2
-      - centos-6-2017-7-py2
-      - fedora-28-2017-7-py2
-      - opensuse-leap-42-2017-7-py2
+    includes:
+      - NONE
     provisioner:
       state_top:
         base:


### PR DESCRIPTION
* Automated using `ssf-formula` (v0.1.0-rc.5)