### PR TITLE
Fix missing value for php.lookup.fpm.user in multi-php mode

### DIFF
--- a/php/ng/map.jinja
+++ b/php/ng/map.jinja
@@ -2272,6 +2272,8 @@
                             'conf': confdir + '/fpm/php-fpm.conf',
                             'ini': confdir + '/fpm/php.ini',
                             'pools': confdir +  '/fpm/pool.d',
+                            'user': 'root',
+                            'group': 'root',
                             'service': 'php' + phpng_version + '-fpm',
                             'user': 'root',
                             'group': 'root',


### PR DESCRIPTION
This fixes the rendering issue:

[CRITICAL] Rendering SLS 'base:php.ng.fpm.config' failed: Jinja variable 'dict object' has no attribute 'user'

When using multiple php versions, this is issued by "{{ php.lookup.fpm.user }}" from php/ng/fpm/config.sls

Add default users in group in the relevant 'fpm' dict from map.jinja
(this is to set owner and group to 'pool.d' directory).