### PR TITLE
fix(pillar.example): fix `octal-values` violation

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -7,9 +7,11 @@ extends: default
 # Files to ignore completely
 # 1. All YAML files under directory `node_modules/`, introduced during the Travis run
 # 2. Any SLS files under directory `test/`, which are actually state files
+# 3. Any YAML files under directory `.kitchen/`, introduced during local testing
 ignore: |
   node_modules/
   test/**/states/**/*.sls
+  .kitchen/
 
 yaml-files:
   # Default settings
@@ -28,3 +30,6 @@ rules:
     # Increase from default of `80`
     # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
     max: 88
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true

--- a/pillar.example
+++ b/pillar.example
@@ -148,7 +148,7 @@ php:
             listen: /var/run/php5-fpm-myapp.sock
             listen.owner: www-data
             listen.group: www-data
-            listen.mode: 0660
+            listen.mode: '0660'
             pm: dynamic
             pm.max_children: 5
             pm.start_servers: 2


### PR DESCRIPTION
* Semi-automated using https://github.com/myii/ssf-formula/pull/59
* https://travis-ci.org/myii/php-formula/builds/594703019#L208-L210

```bash
$ yamllint -s .
./pillar.example
  151:30    error    forbidden implicit octal value "0660"  (octal-values)
```