### PR TITLE
feat(ini) support different settings for php.ini

### DIFF
--- a/php/fpm/config.sls
+++ b/php/fpm/config.sls
@@ -21,6 +21,20 @@
     {%- set conf = php.lookup.fpm.conf|replace(first_version, version) %}
     {%- set pools = php.lookup.fpm.pools|replace(first_version, version) %}
 
+    {%- if version in php.fpm.config.ini %}
+      {%- set ini_settings_versioned = {} %}
+      {%- for key, value in ini_settings.items() %}
+        {%- do ini_settings_versioned.update({key: value.copy()}) %}
+      {%- endfor %}
+      {%- for key, value in php.fpm.config.ini[version].items() %}
+        {%- if ini_settings_versioned[key] is defined %}
+          {%- do ini_settings_versioned[key].update(value) %}
+        {%- else %}
+          {%- do ini_settings_versioned.update({key: value}) %}
+        {%- endif %}
+      {%- endfor %}
+    {%- endif %}
+
     {%- for key, value in conf_settings.items() %}
       {%- if value is string %}
         {%- do conf_settings.update({key: value.replace(first_version, version)}) %}

--- a/pillar.example
+++ b/pillar.example
@@ -102,6 +102,11 @@ php:
             engine: 'Off'
             extension_dir: '/usr/lib/php/modules/'
             extension: [pdo_mysql.so, iconv.so, openssl.so]
+        # if a list of versions is set in php:version, each version
+        # may have different settings
+        # '7.2':
+        #   PHP:
+        #     short_open_tag: 'On'
 
       # options to manage the php-fpm conf file
       conf:
@@ -169,6 +174,11 @@ php:
       settings:
         PHP:
           engine: 'Off'
+      # if a list of versions is set in php:version, each version
+      # may have different settings
+      # '7.2':
+      #   PHP:
+      #     short_open_tag: 'On'
 
   # php-xcache settings
   xcache:


### PR DESCRIPTION
When php:version is a list, a dict with settings for different
versions can be added under ini key of cli and fpm:config keys

```yaml
php:
  fpm:
    config:
      ini:
        settings:
          # global settings
        '5.6':
          # settings for 5.6 only
  cli:
    ini:
      settings:
        # global settings
      '5.6':
        # settings for 5.6 only
```

Related to #138, grandmotivator comment