### PR TITLE
aptkey is deprecated and fails in Debian Trixie

### DIFF
--- a/php/installed.jinja
+++ b/php/installed.jinja
@@ -68,9 +68,10 @@ php_repo_{{ state }}:
 php_ppa_{{ state }}:
   pkgrepo.managed:
     - humanname: {{ external_repo_name }}
-    - name: deb https://packages.sury.org/php/ {{ grains['oscodename'] }} main
+    - name: deb [signed-by=/etc/apt/keyrings/ondrej-php.gpg] https://packages.sury.org/php/ {{ grains['oscodename'] }} main
     - file: /etc/apt/sources.list.d/ondrej-php.list
     - key_url: https://packages.sury.org/php/apt.gpg
+    - aptkey: false
     - __env__:
       - LC_ALL: C.UTF-8
     - onlyif:


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

Fixes Debian Trixie support. Remains backwards compatibility with Debian Bullseye.

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Add the signed-by gpg key attribute and disable (deprecated) aptkey.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

Before: 

```
       ----------
                 ID: php_ppa_fpm
           Function: pkgrepo.managed
               Name: deb https://packages.sury.org/php/ trixie main
             Result: False
            Comment: Failed to configure repo 'deb https://packages.sury.org/php/ trixie main': missing 'signedby' option when apt-key is missing
            Started: 15:55:21.380279
           Duration: 906.368 ms
            Changes:   
       ----------
                 ID: php_install_fpm
           Function: pkg.installed
               Name: fpm
             Result: False
            Comment: One or more requisite failed: php.fpm.install.php_ppa_fpm
            Started: 15:55:22.287931
           Duration: 0.004 ms
            Changes:  
```

After:

```
       ----------
                 ID: php_ppa_fpm
           Function: pkgrepo.managed
               Name: deb [signed-by=/etc/apt/keyrings/ondrej-php.gpg] https://packages.sury.org/php/ trixie main
             Result: True
            Comment: Configured package repo 'deb [signed-by=/etc/apt/keyrings/ondrej-php.gpg] https://packages.sury.org/php/ trixie main'
            Started: 17:03:59.287801
           Duration: 2598.181 ms
            Changes:   
              ----------
              repo:
                  deb [signed-by=/etc/apt/keyrings/ondrej-php.gpg] https://packages.sury.org/php/ trixie main
       ----------
                 ID: php_install_fpm
           Function: pkg.installed
               Name: fpm
             Result: True
            Comment: The following packages were installed/updated: php8.1-fpm
            Started: 17:04:01.888579
           Duration: 13929.164 ms
            Changes:   
              ----------
              libargon2-1:
                  ----------
                  new:
                      0~20190702+dfsg-4+b2
                  old:
              php-common:
                  ----------
                  new:
                      2:101~+0~20260503.72+debian13~1.gbp7da167
                  old:
              php8.1-cli:
                  ----------
                  new:
                      8.1.34-6+0~20260514.80+debian13~1.gbpd8e973
                  old:
              php8.1-common:
                  ----------
                  new:
                      8.1.34-6+0~20260514.80+debian13~1.gbpd8e973
                  old:
              php8.1-fpm:
                  ----------
                  new:
                      8.1.34-6+0~20260514.80+debian13~1.gbpd8e973
                  old:
              php8.1-opcache:
                  ----------
                  new:
                      8.1.34-6+0~20260514.80+debian13~1.gbpd8e973
                  old:
              php8.1-readline:
                  ----------
                  new:
                      8.1.34-6+0~20260514.80+debian13~1.gbpd8e973
                  old:
```



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


